### PR TITLE
Feature: Add OpenAPI3 doc for user_capacities endpoint.

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5190,18 +5190,13 @@ paths:
           Authorization​: only users who can manage topology.
         operationId: createUserCapacity
         parameters:
-          - in: path
-            name: userCapacityId
-            required: true
-            schema:
-              type: string
           - description: User Capacity name.
             in: query
             name: name
-            required: false
+            required: true
             schema:
               type: string
-          - description: The channel id on which apply the capacity.
+          - description: The id of the channel on which the capacities applies.
             in: query
             name: channels[][channel_id]
             required: false
@@ -5293,10 +5288,10 @@ paths:
         - description: User Capacity name.
           in: query
           name: name
-          required: false
+          required: true
           schema:
             type: string
-        - description: The channel id on which apply the capacity.
+        - description: The id of the channel on which the capacities applies.
           in: query
           name: channels[][channel_id]
           required: false

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -38,6 +38,7 @@ x-tag-groups:
       - Time Sheets
       - Timezones
       - Users
+      - User Capacities
   - name: Routing
     popular: true
     tags:
@@ -72,6 +73,7 @@ tags:
   - name: Time Sheets
   - name: Timezones
   - name: Users
+  - name: User Capacities
   - name: Agent Status
   - name: Channels
   - name: Folders
@@ -5179,11 +5181,11 @@ paths:
           description: Success
       summary: Getting all User Capacities
       tags:
-        - UserCapacity
+        - User Capacities
     post:
         description: >-
           This method creates a new user capacity. In case of success it renders the
-          updated record, otherwise, it renders an error (422 HTTP code).
+          created record, otherwise, it renders an error (422 HTTP code).
           Please note that the order of the parameters is important, as the default and
           max capacities will apply to the immediately above channel_id.
 
@@ -5202,13 +5204,13 @@ paths:
             required: false
             schema:
               type: string
-          - description: the default capacity to apply on the previous channel id.
+          - description: The default capacity to apply to the related channel.
             in: query
             name: channels[][default_capacity]
             required: false
             schema:
               type: integer
-          - description: the maximum capacity to apply on the previous channel id.
+          - description: The maximum capacity to apply to the related channel.
             in: query
             name: channels[][max_capacity]
             required: false
@@ -5223,7 +5225,7 @@ paths:
             description: Success
         summary: Creating a user capacity
         tags:
-          - UserCapacity
+          - User Capacities
   '/user_capacities/{userCapacityId}':
     delete:
       description: >-
@@ -5247,10 +5249,10 @@ paths:
           description: Success
       summary: Deleting a user capacity
       tags:
-        - UserCapacity
+        - User Capacities
     get:
       description: >-
-        This method renders a user capacity from given id.
+        This method renders the user capacity corresponding to the id given in parameter.
 
         Authorization​: only users who can manage topology.
       operationId: getUserCapacity
@@ -5269,7 +5271,7 @@ paths:
           description: Success
       summary: Getting a user capacity from its id
       tags:
-        - UserCapacity
+        - User Capacities
     put:
       description: >-
         This method updates an existing user capacity. In case of success it renders the
@@ -5288,7 +5290,7 @@ paths:
         - description: User Capacity name.
           in: query
           name: name
-          required: true
+          required: false
           schema:
             type: string
         - description: The id of the channel on which the capacities applies.
@@ -5297,13 +5299,13 @@ paths:
           required: false
           schema:
             type: string
-        - description: the default capacity to apply on the previous channel id.
+        - description: The default capacity to apply to the related channel.
           in: query
           name: channels[][default_capacity]
           required: false
           schema:
             type: integer
-        - description: the maximum capacity to apply on the previous channel id.
+        - description: The maximum capacity to apply to the related channel.
           in: query
           name: channels[][max_capacity]
           required: false
@@ -5318,7 +5320,7 @@ paths:
           description: Success
       summary: Updating a user capacity
       tags:
-        - UserCapacity
+        - User Capacities
   /users:
     get:
       description: >-

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5177,7 +5177,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/GetAllUserCapacitiesResponse'
+                $ref: '#/components/schemas/GetAllUserCapacitiesResponse'
           description: Success
       summary: Getting all User Capacities
       tags:
@@ -5249,7 +5249,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/UserCapacity'
+                $ref: '#/components/schemas/UserCapacity'
           description: Success
       summary: Deleting a user capacity
       tags:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -79,7 +79,6 @@ tags:
   - name: Folders
   - name: Presence Status
 
-
 paths:
   /attachments:
     get:
@@ -5252,7 +5251,9 @@ paths:
         - User Capacities
     get:
       description: >-
-        This method renders the user capacity corresponding to the id given in parameter.
+        This method renders the user capacity corresponding to the id given in parameter. It
+        renders a 404 if id is invalid.
+
 
         Authorization​: only users who can manage topology.
       operationId: getUserCapacity

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5183,52 +5183,52 @@ paths:
       tags:
         - User Capacities
     post:
-        description: >-
-          This method creates a new user capacity. In case of success it renders the
-          created record, otherwise, it renders an error (422 HTTP code).
+      description: >-
+        This method creates a new user capacity. In case of success it renders the
+        created record, otherwise, it renders an error (422 HTTP code).
 
 
-          Please note that the order of the parameters is important, as the `default_capacity` and
-          `max_capacity` will apply to the immediately above `channel_id`.
+        Please note that the order of the parameters is important, as the `default_capacity` and
+        `max_capacity` will apply to the immediately above `channel_id`.
 
 
-          Authorization​: only users who can manage topology.
-        operationId: createUserCapacity
-        parameters:
-          - description: User Capacity name.
-            in: query
-            name: name
-            required: true
-            schema:
-              type: string
-          - description: The id of the channel on which the capacities apply.
-            in: query
-            name: channels[][channel_id]
-            required: false
-            schema:
-              type: string
-          - description: The default capacity to apply to the related channel.
-            in: query
-            name: channels[][default_capacity]
-            required: false
-            schema:
-              type: integer
-          - description: The maximum capacity to apply to the related channel.
-            in: query
-            name: channels[][max_capacity]
-            required: false
-            schema:
-              type: integer
-        responses:
-          '200':
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/UserCapacity'
-            description: Success
-        summary: Creating a user capacity
-        tags:
-          - User Capacities
+        Authorization​: only users who can manage topology.
+      operationId: createUserCapacity
+      parameters:
+        - description: User Capacity name.
+          in: query
+          name: name
+          required: true
+          schema:
+            type: string
+        - description: The id of the channel on which the capacities apply.
+          in: query
+          name: channels[][channel_id]
+          required: false
+          schema:
+            type: string
+        - description: The default capacity to apply to the related channel.
+          in: query
+          name: channels[][default_capacity]
+          required: false
+          schema:
+            type: integer
+        - description: The maximum capacity to apply to the related channel.
+          in: query
+          name: channels[][max_capacity]
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCapacity'
+          description: Success
+      summary: Creating a user capacity
+      tags:
+        - User Capacities
   '/user_capacities/{userCapacityId}':
     delete:
       description: >-
@@ -5280,15 +5280,15 @@ paths:
         - User Capacities
     put:
       description: >-
-          This method creates a new user capacity. In case of success it renders the
-          created record, otherwise, it renders an error (422 HTTP code).
+        This method creates a new user capacity. In case of success it renders the
+        created record, otherwise, it renders an error (422 HTTP code).
 
 
-          Please note that the order of the parameters is important, as the `default_capacity` and
-          `max_capacity` will apply to the immediately above `channel_id`.
+        Please note that the order of the parameters is important, as the `default_capacity` and
+        `max_capacity` will apply to the immediately above `channel_id`.
 
 
-          Authorization​: only users who can manage topology.
+        Authorization​: only users who can manage topology.
       operationId: updateUserCapacity
       parameters:
         - in: path

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5152,6 +5152,7 @@ paths:
       description: >-
         This method renders all user capacities ordered by creation date (ascending).
 
+
         Authorization​: only users who can manage topology.
       operationId: getAllUserCapacities
       parameters:
@@ -5176,7 +5177,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/GetAllUserCapacities'
+               $ref: '#/components/schemas/GetAllUserCapacitiesResponse'
           description: Success
       summary: Getting all User Capacities
       tags:
@@ -5185,8 +5186,11 @@ paths:
         description: >-
           This method creates a new user capacity. In case of success it renders the
           created record, otherwise, it renders an error (422 HTTP code).
-          Please note that the order of the parameters is important, as the default and
-          max capacities will apply to the immediately above channel_id.
+
+
+          Please note that the order of the parameters is important, as the `default_capacity` and
+          `max_capacity` will apply to the immediately above `channel_id`.
+
 
           Authorization​: only users who can manage topology.
         operationId: createUserCapacity
@@ -5197,7 +5201,7 @@ paths:
             required: true
             schema:
               type: string
-          - description: The id of the channel on which the capacities applies.
+          - description: The id of the channel on which the capacities apply.
             in: query
             name: channels[][channel_id]
             required: false
@@ -5230,6 +5234,7 @@ paths:
       description: >-
         This method destroys an existing user capacity. It renders the user capacity
         itself. It renders a 404 if id is invalid or already destroyed.
+
 
         Authorization​: only users who can manage topology.
       operationId: deleteUserCapacity
@@ -5275,12 +5280,15 @@ paths:
         - User Capacities
     put:
       description: >-
-        This method updates an existing user capacity. In case of success it renders the
-        updated record, otherwise, it renders an error (422 HTTP code).
-        Please note that the order of the parameters is important, as the default and
-        max capacities will apply to the immediately above channel_id.
+          This method creates a new user capacity. In case of success it renders the
+          created record, otherwise, it renders an error (422 HTTP code).
 
-        Authorization​: only users who can manage topology.
+
+          Please note that the order of the parameters is important, as the `default_capacity` and
+          `max_capacity` will apply to the immediately above `channel_id`.
+
+
+          Authorization​: only users who can manage topology.
       operationId: updateUserCapacity
       parameters:
         - in: path
@@ -5294,7 +5302,7 @@ paths:
           required: false
           schema:
             type: string
-        - description: The id of the channel on which the capacities applies.
+        - description: The id of the channel on which the capacities apply.
           in: query
           name: channels[][channel_id]
           required: false
@@ -6956,7 +6964,7 @@ components:
           items:
             $ref: '#/components/schemas/TimeSheet'
           type: array
-    GetAllUserCapacities:
+    GetAllUserCapacitiesResponse:
       properties:
         count:
           format: int32
@@ -7784,8 +7792,6 @@ components:
           format: integer
     UserCapacity:
       properties:
-        name:
-          type: string
         channels:
           items:
             properties:
@@ -7797,6 +7803,16 @@ components:
                 type: integer
             type: object
           type: array
+        created_at:
+          format: date-time
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
     User:
       properties:
         category_ids:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -27,7 +27,7 @@ x-tag-groups:
     tags:
       - Categories
       - CustomFields
-      - Locales      
+      - Locales
       - Reply Assistant Entries
       - Reply Assistant Groups
       - Reply Assistant Versions
@@ -61,7 +61,7 @@ tags:
   - name: Threads
   - name: Categories
   - name: CustomFields
-  - name: Locales  
+  - name: Locales
   - name: Reply Assistant Entries
   - name: Reply Assistant Groups
   - name: Reply Assistant Versions
@@ -77,7 +77,7 @@ tags:
   - name: Folders
   - name: Presence Status
 
-  
+
 paths:
   /attachments:
     get:
@@ -1020,7 +1020,7 @@ paths:
         - Contents
     post:
       description: >-
-        This method allows you to create new content for use in discussions. 
+        This method allows you to create new content for use in discussions.
         It can be a reply to another piece of content or be used to initiate
         discussion. If authorized, the token’s user will be used as the
         content author. Content will be created in Engage Digital and pushed
@@ -5146,6 +5146,184 @@ paths:
       summary: Getting all timezones
       tags:
         - Timezones
+  /user_capacities:
+    get:
+      description: >-
+        This method renders all user capacities ordered by creation date (ascending).
+
+        Authorization​: only users who can manage topology.
+      operationId: getAllUserCapacities
+      parameters:
+        - description: The record index to start. Default value is 0.
+          in: query
+          name: offset
+          required: false
+          schema:
+            format: int32
+            type: integer
+        - description: >-
+            The max number of records to return. Default value is 30, max value
+            is 150.
+          in: query
+          name: limit
+          required: false
+          schema:
+            format: int32
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+               $ref: '#/components/schemas/GetAllUserCapacities'
+          description: Success
+      summary: Getting all User Capacities
+      tags:
+        - UserCapacity
+    post:
+        description: >-
+          This method creates a new user capacity. In case of success it renders the
+          updated record, otherwise, it renders an error (422 HTTP code).
+          Please note that the order of the parameters is important, as the default and
+          max capacities will apply to the immediately above channel_id.
+
+          Authorization​: only users who can manage topology.
+        operationId: createUserCapacity
+        parameters:
+          - in: path
+            name: userCapacityId
+            required: true
+            schema:
+              type: string
+          - description: User Capacity name.
+            in: query
+            name: name
+            required: false
+            schema:
+              type: string
+          - description: The channel id on which apply the capacity.
+            in: query
+            name: channels[][channel_id]
+            required: false
+            schema:
+              type: string
+          - description: the default capacity to apply on the previous channel id.
+            in: query
+            name: channels[][default_capacity]
+            required: false
+            schema:
+              type: integer
+          - description: the maximum capacity to apply on the previous channel id.
+            in: query
+            name: channels[][max_capacity]
+            required: false
+            schema:
+              type: integer
+        responses:
+          '200':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UserCapacity'
+            description: Success
+        summary: Creating a user capacity
+        tags:
+          - UserCapacity
+  '/user_capacities/{userCapacityId}':
+    get:
+      description: >-
+        This method renders a user capacity from given id.
+
+        Authorization​: only users who can manage topology.
+      operationId: getUserCapacity
+      parameters:
+        - in: path
+          name: userCapacityId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCapacity'
+          description: Success
+      summary: Getting a user capacity from its id
+      tags:
+        - UserCapacity
+    delete:
+      description: >-
+        This method destroys an existing user capacity. It renders the user capacity
+        itself. It renders a 404 if id is invalid or already destroyed.
+
+        Authorization​: only users who can manage topology.
+      operationId: deleteUserCapacity
+      parameters:
+        - in: path
+          name: userCapacityId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/UserCapacity'
+          description: Success
+      summary: Deleting a user capacity
+      tags:
+        - UserCapacity
+    put:
+      description: >-
+        This method updates an existing user capacity. In case of success it renders the
+        updated record, otherwise, it renders an error (422 HTTP code).
+        Please note that the order of the parameters is important, as the default and
+        max capacities will apply to the immediately above channel_id.
+
+        Authorization​: only users who can manage topology.
+      operationId: updateUserCapacity
+      parameters:
+        - in: path
+          name: userCapacityId
+          required: true
+          schema:
+            type: string
+        - description: User Capacity name.
+          in: query
+          name: name
+          required: false
+          schema:
+            type: string
+        - description: The channel id on which apply the capacity.
+          in: query
+          name: channels[][channel_id]
+          required: false
+          schema:
+            type: string
+        - description: the default capacity to apply on the previous channel id.
+          in: query
+          name: channels[][default_capacity]
+          required: false
+          schema:
+            type: integer
+        - description: the maximum capacity to apply on the previous channel id.
+          in: query
+          name: channels[][max_capacity]
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCapacity'
+          description: Success
+      summary: Updating a user capacity
+      tags:
+        - UserCapacity
   /users:
     get:
       description: >-
@@ -6780,6 +6958,21 @@ components:
           items:
             $ref: '#/components/schemas/TimeSheet'
           type: array
+    GetAllUserCapacities:
+      properties:
+        count:
+          format: int32
+          type: integer
+        limit:
+          format: int32
+          type: integer
+        offset:
+          format: int32
+          type: integer
+        records:
+          items:
+            $ref: '#/components/schemas/UserCapacity'
+          type: array
     GetAllUsersResponse:
       properties:
         count:
@@ -7591,6 +7784,21 @@ components:
           format: string
         utc_offset:
           format: integer
+    UserCapacity:
+      properties:
+        name:
+          type: string
+        channels:
+          item:
+            properties:
+              id:
+                type: string
+              default_capacity:
+                type: int
+              max_capacity:
+                type: int
+            type: object
+          type: array
     User:
       properties:
         category_ids:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5225,28 +5225,6 @@ paths:
         tags:
           - UserCapacity
   '/user_capacities/{userCapacityId}':
-    get:
-      description: >-
-        This method renders a user capacity from given id.
-
-        Authorization​: only users who can manage topology.
-      operationId: getUserCapacity
-      parameters:
-        - in: path
-          name: userCapacityId
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserCapacity'
-          description: Success
-      summary: Getting a user capacity from its id
-      tags:
-        - UserCapacity
     delete:
       description: >-
         This method destroys an existing user capacity. It renders the user capacity
@@ -5268,6 +5246,28 @@ paths:
                   $ref: '#/components/schemas/UserCapacity'
           description: Success
       summary: Deleting a user capacity
+      tags:
+        - UserCapacity
+    get:
+      description: >-
+        This method renders a user capacity from given id.
+
+        Authorization​: only users who can manage topology.
+      operationId: getUserCapacity
+      parameters:
+        - in: path
+          name: userCapacityId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCapacity'
+          description: Success
+      summary: Getting a user capacity from its id
       tags:
         - UserCapacity
     put:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7784,14 +7784,14 @@ components:
         name:
           type: string
         channels:
-          item:
+          items:
             properties:
               id:
                 type: string
               default_capacity:
-                type: int
+                type: integer
               max_capacity:
-                type: int
+                type: integer
             type: object
           type: array
     User:


### PR DESCRIPTION
Adding documentation for new endpoint we are currently developing.

A few remarks on POST and PUT requests : 

- We might want to specify that some params (eg: L5204-L5221) can be used several times.

- We might want to explain about the orders of the params :

A request with params
name:Cap
channels[][channel_id]:id_1
channels[][default_capacity]:1
channels[][max_capacity]:2
channels[][channel_id]:id_2
channels[][default_capacity]:1
channels[][max_capacity]:10

And with params (just switching orders) :

name:Cap
channels[][channel_id]:id_1
channels[][channel_id]:id_2
channels[][default_capacity]:1
channels[][max_capacity]:2
channels[][default_capacity]:1
channels[][max_capacity]:10

Will NOT yield the same results (actually the second one will be rejected).

I tried to mention it on the documentation but it might be unclear, so I wanted to bring that up.

[Ticket](https://jira.ringcentral.com/browse/RD-15138)