### PR TITLE
api: add variables to endpoint url of openapi spec, fixes #19

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -13,7 +13,7 @@ servers:
         description: Your own account name used as subdomain, it's the same as in the url of the engage digital service.
       platform_hostname:
         default: api.engagement.dimelo.com
-        description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.
+        description: Depending on environment the base hostname is changing. In production, it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.com for historical customers. It's the same base hostname as in the url of engage digital service.
 x-tag-groups:
   - name: Events & Notifications
     tags:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -3,7 +3,7 @@ info:
   description: ''
   termsOfService: 'https://developer.ringcentral.com'
   title: RingCentral Engage Digital API
-  version: '1.01'
+  version: '1.0.1'
 servers:
   - url: 'https://{account_name}.api.{platform_hostname}/1.0'
     description: API server endpoint

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -10,7 +10,7 @@ servers:
     variables:
       account_name:
         default: domainname
-        description: your own account name used as subdomain, it's the same as in the url of the engage digital service.
+        description: Your own account name used as subdomain, it's the same as in the url of the engage digital service.
       platform_hostname:
         default: api.engagement.dimelo.com
         description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5,7 +5,18 @@ info:
   title: RingCentral Engage Digital API
   version: '1.0'
 servers:
-  - url: 'https://<yourdomain>.api.engagement.dimelo.com/1.0'
+  - url: 'https://{account_name}.{platform_hostname}/1.0'
+    description: API server endpoint
+    variables:
+      account_name:
+        default: yourname
+        description: your own account name used as subdomain, it's the same as in the url of the engage digital service.
+      platform_hostname:
+        enum:
+          - api.digital.ringcentral.com
+          - api.engagement.dimelo.com
+        description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.
+        default: api.engagement.dimelo.com
 x-tag-groups:
   - name: Events & Notifications
     tags:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -9,7 +9,7 @@ servers:
     description: API server endpoint
     variables:
       account_name:
-        default: domainname
+        default: domain-name
         description: Your own account name used as subdomain, it's the same as in the url of the engage digital service.
       platform_hostname:
         default: api.engagement.dimelo.com

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -3,7 +3,7 @@ info:
   description: ''
   termsOfService: 'https://developer.ringcentral.com'
   title: RingCentral Engage Digital API
-  version: '1.0'
+  version: '1.01'
 servers:
   - url: 'https://{account_name}.api.{platform_hostname}/1.0'
     description: API server endpoint
@@ -12,8 +12,8 @@ servers:
         default: domain-name
         description: Your own account name used as subdomain, it's the same as in the url of the engage digital service.
       platform_hostname:
-        default: api.engagement.dimelo.com
-        description: Depending on environment the base hostname is changing. In production, it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.com for historical customers. It's the same base hostname as in the url of engage digital service.
+        default: engagement.dimelo.com
+        description: Depending on environment the base hostname is changing. In production, it's digital.ringcentral.com for NA customers and engagement.dimelo.com for historical customers. It's the same base hostname as in the url of engage digital service.
 x-tag-groups:
   - name: Events & Notifications
     tags:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -9,15 +9,12 @@ servers:
     description: API server endpoint
     variables:
       account_name:
-        default: yourname
+        default: domainname
         description: your own account name used as subdomain, it's the same as in the url of the engage digital service.
       platform_hostname:
-        enum:
-          - api.digital.ringcentral.com
-          - api.engagement.dimelo.com
-        description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.
         default: api.engagement.dimelo.com
-x-tag-groups:
+        description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.
+       x-tag-groups:
   - name: Events & Notifications
     tags:
       - Events

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -5,7 +5,7 @@ info:
   title: RingCentral Engage Digital API
   version: '1.0'
 servers:
-  - url: 'https://{account_name}.{platform_hostname}/1.0'
+  - url: 'https://{account_name}.api.{platform_hostname}/1.0'
     description: API server endpoint
     variables:
       account_name:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -14,7 +14,7 @@ servers:
       platform_hostname:
         default: api.engagement.dimelo.com
         description: Depending on environment the base hostname is changing. In production it's api.digital.ringcentral.com for NA customers and api.engagement.dimelo.comfor historical customers. It's the same base hostname as in the url of engage digital service.
-       x-tag-groups:
+x-tag-groups:
   - name: Events & Notifications
     tags:
       - Events


### PR DESCRIPTION
Make variables url follow openapi spec for better website generation #19

hostname is not enum to support more than just prod.

Pity it does not work in editor.swagger.io because of CORS headers (it's intentional as I don't want to incentivize people to use global api token in the browser but it's a bit painful for this particular usecase.

Could not test bearer because of that