### PR TITLE
Better: Add filter parameters to Status API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -4304,6 +4304,39 @@ paths:
 
         Authorization​: only users that have the right to monitor the task view.
       operationId: getAllAgentStatus
+      parameters:
+        - description: To filter users on given source ids (based on reply permission).
+          in: query
+          name: source_ids
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
+        - description: To filter users on given category ids.
+          in: query
+          name: category_ids
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
+        - description: To filter users on given team ids.
+          in: query
+          name: team_ids
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
+        - description: To filter users on given locales.
+          in: query
+          name: spoken_languages
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         '200':
           content:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -5937,6 +5937,32 @@
                   "path": [
                     "1.0",
                     "status"
+                  ],
+                  "query": [
+                    {
+                      "key": "source_ids",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "To filter users on given source ids (based on reply permission).",
+                      "disabled": true
+                    },
+                    {
+                      "key": "category_ids",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "To filter users on given category ids.",
+                      "disabled": true
+                    },
+                    {
+                      "key": "team_ids",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "To filter users on given team ids.",
+                      "disabled": true
+                    },
+                    {
+                      "key": "spoken_languages",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "To filter users on given locales.",
+                      "disabled": true
+                    }
                   ]
                 },
                 "method": "GET",


### PR DESCRIPTION
Status API currently doesn't include filter parameters when fetching all users while there are some
- source_ids
- category_ids
- team_ids
- spoken_languages

also updated postman collection