### PR TITLE
Add documentation for email credentials updating. RD-18084

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -768,6 +768,54 @@ paths:
       summary: Updating a source
       tags:
         - Sources
+  /content_sources/{sourceId}/email_credentials:
+    put:
+      description: >-
+        This method updates credentials for IMAP and SMTP adapters of email sources. In case of success
+        it renders the content source, otherwise, it renders an error (422 HTTP code).
+      operationId: updateSourceEmailCredentials
+      parameters:
+        - in: path
+          name: sourceId
+          required: true
+          schema:
+            type: string
+        - description: IMAP username
+          in: query
+          name: imap[username]
+          required: false
+          schema:
+            type: string
+        - description: IMAP password
+          in: query
+          name: imap[password]
+          required: false
+          schema:
+            type: string
+        - description: SMTP username
+          in: query
+          name: smtp[username]
+          required: false
+          schema:
+            type: string
+        - description: SMTP password
+          in: query
+          name: smtp[password]
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Source'
+          description: Success
+        '422':
+          description: Unprocessable Entity
+      summary: Updating source credentials
+      tags:
+        - Sources
   /content_threads:
     get:
       description: >-

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1771,6 +1771,61 @@
                 ],
                 "description": "This method updates an existing source from given attributes and renders it in case of success."
               }
+            },
+            {
+              "name": "Updating source credentials",
+              "request": {
+                "url": {
+                  "raw": "{{ENGAGE_DIGITAL_SERVER_URL}}/1.0/content_sources/:sourceId/email_credentials",
+                  "host": [
+                    "{{ENGAGE_DIGITAL_SERVER_URL}}"
+                  ],
+                  "path": [
+                    "1.0",
+                    "content_sources",
+                    ":sourceId",
+                    "email_credentials"
+                  ],
+                  "query": [
+                    {
+                      "key": "imap[username]",
+                      "value": "\u003cstring\u003e",
+                      "description": "IMAP username",
+                      "disabled": true
+                    },
+                    {
+                      "key": "imap[password]",
+                      "value": "\u003cstring\u003e",
+                      "description": "IMAP password",
+                      "disabled": true
+                    },
+                    {
+                      "key": "smtp[username]",
+                      "value": "\u003cstring\u003e",
+                      "description": "SMTP username",
+                      "disabled": true
+                    },
+                    {
+                      "key": "smtp[password]",
+                      "value": "\u003cstring\u003e",
+                      "description": "SMTP password",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "description": "This method updates credentials for IMAP and SMTP adapters of email sources. In case of success it renders the content source, otherwise, it renders an error (422 HTTP code)."
+              }
             }
           ]
         },


### PR DESCRIPTION
This PR adds documentation for the new endpoint to update credentials of email sources for imap/smtp adapters.
**Please, don't merge it until the feature MR is merged.**