### PR TITLE
Add `mdx_include` to the mkdocs installing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ If you would like to contribute to the RingCentral documentation effort, fork th
 ```
 % git clone https://github.com/ringcentral/engage-digital-api-docs.git
 % cd engage-digital-api-docs
-% pip install mkdocs
-% pip install mkdocs-ringcentral
+% pip install mkdocs mkdocs-ringcentral mdx_include
 % mkdocs serve
 ```
 


### PR DESCRIPTION
We missed the `mdx_include` package that's needed to run the mkdocs server. so I've added it and joined all pip dependencies installation into a single line command.