### PR TITLE
Updated Quick Start Guide with correct URL in sample code and docs

### DIFF
--- a/code-samples/interactions/threads.js
+++ b/code-samples/interactions/threads.js
@@ -1,6 +1,6 @@
 var https = require('https')
 
-const SERVER = '<YOUR-DOMAIN>.api.engagement.dimelo.com'
+const SERVER = '<YOUR-DOMAIN>.api.digital.ringcentral.com'
 const ACCESS_TOKEN = '<API-ACCESS-TOKEN>'
 const API = "/1.0/content_threads"
 

--- a/code-samples/interactions/threads.php
+++ b/code-samples/interactions/threads.php
@@ -1,5 +1,5 @@
 <?php
-$SERVER = "https://<YOUR-DOMAIN>.api.engagement.dimelo.com";
+$SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com";
 $ACCESS_TOKEN = '<API-ACCESS-TOKEN>';
 $API = "/1.0/content_threads";
 

--- a/code-samples/interactions/threads.php
+++ b/code-samples/interactions/threads.php
@@ -1,5 +1,5 @@
 <?php
-$SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com";
+$SERVER = "https://<YOUR-DOMAIN>.api.digital.ringcentral.com";
 $ACCESS_TOKEN = '<API-ACCESS-TOKEN>';
 $API = "/1.0/content_threads";
 

--- a/code-samples/interactions/threads.py
+++ b/code-samples/interactions/threads.py
@@ -1,6 +1,6 @@
 import requests
 
-SERVER = "https://<YOUR-DOMAIN>.api.engagement.dimelo.com"
+SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com"
 ACCESS_TOKEN = '<API-ACCESS-TOKEN>'
 API = "/1.0/content_threads"
 

--- a/code-samples/interactions/threads.py
+++ b/code-samples/interactions/threads.py
@@ -1,6 +1,6 @@
 import requests
 
-SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com"
+SERVER = "https://<YOUR-DOMAIN>.api.digital.ringcentral.com"
 ACCESS_TOKEN = '<API-ACCESS-TOKEN>'
 API = "/1.0/content_threads"
 

--- a/code-samples/interactions/threads.rb
+++ b/code-samples/interactions/threads.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 
-SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com"
+SERVER = "https://<YOUR-DOMAIN>.api.digital.ringcentral.com"
 ACCESS_TOKEN = '<API-ACCESS-TOKEN>'
 API = "/1.0/content_threads"
 

--- a/code-samples/interactions/threads.rb
+++ b/code-samples/interactions/threads.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 
-SERVER = "https://<YOUR-DOMAIN>.api.engagement.dimelo.com/"
+SERVER = "https://<YOUR-DOMAIN>.digital.ringcentral.com"
 ACCESS_TOKEN = '<API-ACCESS-TOKEN>'
 API = "/1.0/content_threads"
 

--- a/docs/interactions/quick-start.md
+++ b/docs/interactions/quick-start.md
@@ -25,7 +25,7 @@ Make note of the access token generated as you will need it later.
 
 === "Javascript"
 
-    Create a file called `threads.js`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials.
+    Create a file called `threads.js`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials. You can find information about **&lt;YOUR-DOMAIN&gt;** when you login into Engage Digital Admin portal. Copy the first part before the "." from the url which should look like : `https://xyz.digital.ringcentral.com`. So in this case the your domain is "xyz".
 
     ```javascript
     {!> code-samples/interactions/threads.js !}
@@ -41,7 +41,7 @@ Make note of the access token generated as you will need it later.
 
 === "Python"
 
-    Create a file called `threads.py`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials.
+    Create a file called `threads.py`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials. You can find information about **&lt;YOUR-DOMAIN&gt;** when you login into Engage Digital Admin portal. Copy the first part before the "." from the url which should look like : `https://xyz.digital.ringcentral.com`. So in this case the your domain is "xyz".
 
     ```python
     {!> code-samples/interactions/threads.py !}
@@ -57,7 +57,7 @@ Make note of the access token generated as you will need it later.
 
 === "PHP"
 
-    Create a file called `threads.php`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials.
+    Create a file called `threads.php`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials. You can find information about **&lt;YOUR-DOMAIN&gt;** when you login into Engage Digital Admin portal. Copy the first part before the "." from the url which should look like : `https://xyz.digital.ringcentral.com`. So in this case the your domain is "xyz".
 
     ```php
     {!> code-samples/interactions/threads.php !}
@@ -73,7 +73,7 @@ Make note of the access token generated as you will need it later.
 
 === "Ruby"
 
-    Create a file called `threads.rb`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials.
+    Create a file called `threads.rb`. Be sure to edit the variables in &lt;ALL CAPS&gt; with your app's credentials. You can find information about **&lt;YOUR-DOMAIN&gt;** when you login into Engage Digital Admin portal. Copy the first part before the "." from the url which should look like : `https://xyz.digital.ringcentral.com`. So in this case the your domain is "xyz".
 
     ```ruby
     {!> code-samples/interactions/threads.rb !}


### PR DESCRIPTION
PR has important changes in the quick start guide, the URL for the server was obsolete and docs were missing information on how to find one's sub-domain information. I've updated both of those in this code change.