### PR TITLE
Feature: Add Surveys API endpoint documentation. RD-19829

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -8113,7 +8113,7 @@ components:
         foreign_id:
           description: |-
             The survey provider's id for this question.
-          type: number
+          type: string
         main:
           type: boolean
         text:
@@ -8126,14 +8126,17 @@ components:
             List of choices end user can select to answer this question.
           items:
             $ref: '#/components/schemas/SurveyQuestionChoices'
+          type: array
     SurveyQuestionChoices:
       properties:
         text:
           description: |-
             Choice text viewed by the end user.
+          type: string
         value:
           description: |-
             Technical value, same as text for text inputs.
+          type: string
     SurveyQuestionReply:
       properties:
         text:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -33,6 +33,7 @@ x-tag-groups:
       - Intervention Comments
       - Interventions
       - Sources
+      - Survey Responses
       - Surveys
       - Threads
   - name: Provisioning
@@ -92,6 +93,7 @@ tags:
   - name: Channels
   - name: Folders
   - name: Presence Status
+  - name: Survey Responses
   - name: Surveys
 
 paths:
@@ -4470,7 +4472,7 @@ paths:
           description: Success
       summary: Get a survey response
       tags:
-        - Surveys
+        - Surveys Responses
   '/status/{agentId}':
     get:
       description: >-

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -8069,18 +8069,6 @@ components:
           description: |-
             Delay before sending survey to end users.
           type: number
-        last_activated_at:
-          description: |-
-            Internal field.
-            Updated each time the survey is enabled on the ED admin interface.
-          format: date-time
-          type: string
-        last_response_at:
-          description: |-
-            Internal field.
-            Time of last survey response. Used for polling responses from provider.
-          format: date-time
-          type: string
         category_ids:
           items:
             type: string

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -8059,11 +8059,11 @@ components:
           type: string
         instant_send_threshold:
           description: |-
-            All intervention whose duration is shorter than this value (in seconds) will have the survey sent instantly.
+            Any intervention whose duration is shorter than this value (in seconds) will have the survey sent instantly.
           type: number
         max_time_since_last_reply:
           description: |-
-            If last message from end user is older than this value (in seconds), no survey will be sent.
+            If last message from end user is older than this duration (in seconds), no survey will be sent.
           type: number
         send_delay:
           description: |-

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -33,7 +33,7 @@ x-tag-groups:
       - Intervention Comments
       - Interventions
       - Sources
-      - Survey Responses
+      - Surveys
       - Threads
   - name: Provisioning
     tags:
@@ -92,7 +92,7 @@ tags:
   - name: Channels
   - name: Folders
   - name: Presence Status
-  - name: Survey Responses
+  - name: Surveys
 
 paths:
   /attachments:
@@ -4414,6 +4414,42 @@ paths:
       summary: Get all connected agents status
       tags:
         - Agent Status
+  /surveys:
+    get:
+      description: >-
+        This method renders all surveys ordered by creation date (most recent first).
+      operationId: getAllSurveys
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Survey'
+          description: Success
+      summary: Getting all surveys
+      tags:
+        - Surveys
+  '/surveys/{surveyId}':
+    get:
+      description: >-
+        This method renders a survey from its id.
+      operationId: getSurvey
+      parameters:
+        - in: path
+          name: surveyId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Survey'
+          description: Success
+      summary: Getting a survey from its id
+      tags:
+        - Surveys
   '/survey_responses/{surveyResponseId}':
     get:
       description: >-
@@ -4434,7 +4470,7 @@ paths:
           description: Success
       summary: Get a survey response
       tags:
-        - Survey Responses
+        - Surveys
   '/status/{agentId}':
     get:
       description: >-
@@ -7978,6 +8014,109 @@ components:
           items:
             type: string
           type: array
+    Survey:
+      properties:
+        id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        name:
+          description: |-
+            Name displayed in ED admin interface.
+            Is not displayed to end users.
+          type: string
+        link:
+          description: |-
+            Link to the survey on the provider website.
+          type: string
+        active:
+          type: boolean
+        from_name:
+          description: |-
+            Name displayed as sender when survey is sent to end user.
+            Currently only applies to surveys sent by email.
+          type: string
+        instant_send_threshold:
+          description: |-
+            All intervention shorter than this value (in seconds) will have the survey sent instantly.
+          type: number
+        max_time_since_last_reply:
+          description: |-
+            If last message from end user is older than this value (in seconds), no survey will be sent.
+          type: number
+        send_delay:
+          description: |-
+            Delay before sending survey to end users.
+          type: number
+        send_message:
+          type: string
+        last_activated_at:
+          description: |-
+            Internal field.
+            Updated each time the survey is enabled on the ED admin interface.
+          format: date-time
+          type: string
+        last_response_at:
+          description: |-
+            Internal field.
+            Time of last survey response. Used for polling responses from provider.
+          format: date-time
+          type: string
+        category_ids:
+          items:
+            type: string
+          type: array
+        team_ids:
+          items:
+            type: string
+          type: array
+        source_ids:
+          items:
+            type: string
+          type: array
+        type:
+          description: |-
+            Contains the information of the survey provider used.
+            Currently, only provider supported is alchemer.
+          enum: ['alchemer']
+          type: string
+        questions:
+          description: |-
+            Fetched from survey provider.
+            List of questions asked in this survey.
+          items:
+            $ref: '#/components/schemas/SurveyQuestion'
+          type: array
+    SurveyQuestion:
+      properties:
+        foreign_id:
+          description: |-
+            The survey provider's id for this question.
+          type: number
+        main:
+          type: boolean
+        text:
+          description: |-
+            The question's body.
+          type: string
+        choices:
+          description: |-
+            Fetched from survey provider.
+            List of choices end user can elect to answer this question.
+          items:
+            $ref: '#/components/schemas/SurveyQuestionChoices'
+    SurveyQuestionChoices:
+      properties:
+        text:
+          description: |-
+            Choice text viewed by the end user.
+        value:
+          description: |-
+            Technical value, same as text for text inputs.
     SurveyQuestionReply:
       properties:
         text:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -4472,7 +4472,7 @@ paths:
           description: Success
       summary: Get a survey response
       tags:
-        - Surveys Responses
+        - Survey Responses
   '/status/{agentId}':
     get:
       description: >-

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -4424,7 +4424,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Survey'
+                $ref: '#/components/schemas/getAllSurveysResponse'
           description: Success
       summary: Getting all surveys
       tags:
@@ -7247,6 +7247,21 @@ components:
         records:
           items:
             $ref: '#/components/schemas/Source'
+          type: array
+    getAllSurveysResponse:
+      properties:
+        count:
+          format: int32
+          type: integer
+        limit:
+          format: int32
+          type: integer
+        offset:
+          format: int32
+          type: integer
+        records:
+          items:
+            $ref: '#/components/schemas/Survey'
           type: array
     GetAllTagsResponse:
       properties:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -8069,8 +8069,6 @@ components:
           description: |-
             Delay before sending survey to end users.
           type: number
-        send_message:
-          type: string
         last_activated_at:
           description: |-
             Internal field.
@@ -8099,7 +8097,8 @@ components:
           description: |-
             Contains the information of the survey provider used.
             Currently, only provider supported is alchemer.
-          enum: ['alchemer']
+          enum:
+            - alchemer
           type: string
         questions:
           description: |-

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -4419,7 +4419,7 @@ paths:
   /surveys:
     get:
       description: >-
-        This method renders all surveys ordered by creation date (most recent first).
+        This method renders all surveys ordered by creation date (ascending).
       operationId: getAllSurveys
       responses:
         '200':
@@ -4434,7 +4434,7 @@ paths:
   '/surveys/{surveyId}':
     get:
       description: >-
-        This method renders a survey from its id.
+        This method renders a survey from given id.
       operationId: getSurvey
       parameters:
         - in: path
@@ -8059,7 +8059,7 @@ components:
           type: string
         instant_send_threshold:
           description: |-
-            All intervention shorter than this value (in seconds) will have the survey sent instantly.
+            All intervention whose duration is shorter than this value (in seconds) will have the survey sent instantly.
           type: number
         max_time_since_last_reply:
           description: |-
@@ -8123,7 +8123,7 @@ components:
         choices:
           description: |-
             Fetched from survey provider.
-            List of choices end user can elect to answer this question.
+            List of choices end user can select to answer this question.
           items:
             $ref: '#/components/schemas/SurveyQuestionChoices'
     SurveyQuestionChoices:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1830,7 +1830,7 @@
           ]
         },
         {
-          "name": "Survey Responses",
+          "name": "Surveys",
           "description": {
             "type": "text/plain"
           },
@@ -1861,6 +1861,61 @@
                   }
                 ],
                 "description": "This method returns information about a survey response."
+              }
+            },
+            {
+              "name": "Getting all surveys",
+              "request": {
+                "url": {
+                  "raw": "{{ENGAGE_DIGITAL_SERVER_URL}}/1.0/surveys",
+                  "host": [
+                    "{{ENGAGE_DIGITAL_SERVER_URL}}"
+                  ],
+                  "path": [
+                    "1.0",
+                    "surveys"
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "description": "This method renders all surveys ordered by creation date (most recent first)."
+              }
+            },
+            {
+              "name": "Getting a survey from its id",
+              "request": {
+                "url": {
+                  "raw": "{{ENGAGE_DIGITAL_SERVER_URL}}/1.0/surveys/:surveyId",
+                  "host": [
+                    "{{ENGAGE_DIGITAL_SERVER_URL}}"
+                  ],
+                  "path": [
+                    "1.0",
+                    "surveys",
+                    ":surveyId"
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "description": "This method renders a survey from its id."
               }
             }
           ]

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1830,7 +1830,7 @@
           ]
         },
         {
-          "name": "Surveys",
+          "name": "Survey Responses",
           "description": {
             "type": "text/plain"
           },
@@ -1862,7 +1862,15 @@
                 ],
                 "description": "This method returns information about a survey response."
               }
-            },
+            }
+          ]
+        },
+        {
+          "name": "Surveys",
+          "description": {
+            "type": "text/plain"
+          },
+          "item": [
             {
               "name": "Getting all surveys",
               "request": {
@@ -1887,7 +1895,7 @@
                     "value": "application/json"
                   }
                 ],
-                "description": "This method renders all surveys ordered by creation date (most recent first)."
+                "description": "This method renders all surveys ordered by creation date (ascending)."
               }
             },
             {
@@ -1915,7 +1923,7 @@
                     "value": "application/json"
                   }
                 ],
-                "description": "This method renders a survey from its id."
+                "description": "This method renders a survey from given id."
               }
             }
           ]


### PR DESCRIPTION
Hey !

Ticket(s):
 * [RD-19829](https://jira.ringcentral.com/browse/RD-19829)

Change(s):
 * Add Surveys endpoint doc
 
I Merged survey_response and surveys into the same section, this is debatable as it's not the same url, but it was clearer doc-wise. If you disagree, I can make it into to two separate sections. Discussion on the subject [here](https://github.com/ringcentral/engage-digital-api-docs/pull/52#discussion_r746791601) in the comments below

Ping @CedricBm PR is ready for review