### PR TITLE
Feature: add info about UTF-16 code units adaptation in WhatsApp

### DIFF
--- a/docs/interactions/structured-messages/select.md
+++ b/docs/interactions/structured-messages/select.md
@@ -283,17 +283,17 @@ Primary parameters are used by default, however, some parameters are unique or o
 |-|-|-|
 | **Structured Content Settings** | | |
 | **`structured_content.items`** | Array | Truncated to 10 elements. |
-| **`structured_content.button`** | String | **Optional**. The button text field.<br>Limited to 20 characters. "See options" by default. |
-| **`structured_content.title`** | String | **Optional**. The title text field.<br>Limited to 60 characters.  |
-| **`structured_content.footer`** | String | **Optional**. The footer text field.<br>Limited to 60 characters.  |
+| **`structured_content.button`** | String | **Optional**. The button text field.<br>Limited to 20 characters.<br>*Truncated to 20 UTF-16 code units.*<br>"See options" by default. |
+| **`structured_content.title`** | String | **Optional**. The title text field.<br>Limited to 60 characters.<br>*Truncated to 60 UTF-16 code units.* |
+| **`structured_content.footer`** | String | **Optional**. The footer text field.<br>Limited to 60 characters.<br>*Truncated to 60 UTF-16 code units.* |
 | **Section Settings** | | |
 | **`structured_content.sections`** | Array | **Optional**. Limited to 10 elements. |
-| **`structured_content.sections.title`** | String | **Optional if there's only a single section**. The title of the section.<br>Limited to 24 characters. |
+| **`structured_content.sections.title`** | String | **Optional if there's only a single section**. The title of the section.<br>Limited to 24 characters.<br>*Truncated to 24 UTF-16 code units.* |
 | **`structured_content.sections.identifier`** | String | Identifier of the section that will be used to organize items in the section.<br>Limited to 200 characters. |
 | **Item Settings** | | |
-| **`structured_content.items.title`** | String | The item title field.<br>Truncated to 24 characters. |
+| **`structured_content.items.title`** | String | The item title field.<br>Truncated to 24 characters.<br>*Truncated to 24 UTF-16 code units.* |
 | **`structured_content.items.payload`** | String | **Optional**. The item payload field.<br>Limited to 200 characters.<br>Automatically gets populated as a random hex if blank. |
-| **`structured_content.items.description`** | String | **Optional**. The item description text field.<br>Limited to 72 characters. |
+| **`structured_content.items.description`** | String | **Optional**. The item description text field.<br>Limited to 72 characters.<br>*Truncated to 72 UTF-16 code units.* |
 | **`structured_content.items.section_identifier`** | String | **Optional if there's no sections**. The identifier of the section where the item is.<br>If there's no sections, the section_identifier field should be removed.<br>Each section must have at least 1 item.<br>Limited to 200 characters. |
 
 ##  Example: Instagram Messaging (Quick Replies)

--- a/docs/interactions/structured-messages/template.md
+++ b/docs/interactions/structured-messages/template.md
@@ -130,20 +130,20 @@ Primary parameters are used by default, however, some parameters are unique or o
 | API Property | Type | Specificity |
 |-|-|-|
 | **If subtitle is present** | | |
-| **`structured_content.title`** | String | Truncated to 60 characters. |
-| **`structured_content.subtitle`** | String | Truncated to 963 characters if an attachment is present. |
+| **`structured_content.title`** | String | *Truncated to 60 UTF-16 code units.* |
+| **`structured_content.subtitle`** | String | *Truncated to 963 UTF-16 code units if an attachment is present.* |
 | **If subtitle is empty** | | |
-| **`structured_content.title`** | String | Limited to 1000 characters. Used as the message body. |
+| **`structured_content.title`** | String | Limited to 1000 characters.<br>*Truncated to 1000 UTF-16 code units.*<br>Used as the message body. |
 | **Structured Content Settings** | | |
 | **`structured_content.attachment_id`** | String | Supports jpg, jpeg, png, mp4 formats. Supports private attachments. [Upload attachments](../../../basics/uploads) for your own custom images or videos. Should be less than 64 MB. WhatsApp supports videos with only H.264 and AAC codecs and a single audio stream. |
-| **`structured_content.footer`** | String | Limited to 60 characters. |
+| **`structured_content.footer`** | String | Limited to 60 characters.<br>*Truncated to 60 UTF-16 code units.* |
 | **`structured_content.url`** | String | **Ignored** property. |
 | **`structured_content.url_fallback`** | String | **Ignored** property. |
 | **`structured_content.url_text`** | String | **Ignored** property. |
 | **Item Settings** | | |
 | **`structured_content.items`** | Array | Truncated to 3 elements. |
 | **`structured_content.items.type`** | String | Only `reply` is supported. |
-| **`structured_content.items.title`** | String | Truncated to 20 charactes. |
+| **`structured_content.items.title`** | String | Truncated to 20 charactes.<br>*Truncated to 20 UTF-16 code units.* |
 | **`structured_content.items.payload`** | String | Limited to 256 characters.<br>Automatically gets populated as a random hex if blank. |
 | **`structured_content.items.url`** | String | **Ignored** property. |
 | **`structured_content.items.url_fallback`** | String | **Ignored** property. |


### PR DESCRIPTION
In RD-19682 we introduced new adaptation that truncates text fields if they exceed the UTF-16 code units max count because WhatsApp has slightly different validation.

This MR updates the documentation to keep it up to date.