### PR TITLE
Better: Add surveys extension related fields to intervention schema. RD-20478

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7587,7 +7587,7 @@ components:
             Only present when customer satisfaction extension is enabled.
         survey_id:
           type: string
-          description: |
+          description: |-
             ED internal ID for satisfaction survey.
             Only present when customer satisfaction extension is enabled.
       required:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7556,6 +7556,40 @@ components:
           type: integer
         user_reply_in_average_count:
           type: integer
+        satisfaction_grade:
+          type: integer
+          description: |-
+            Satisfaction grade.
+            Only present when customer satisfaction extension is enabled.
+        satisfaction_survey_id:
+          type: integer
+          deprecated: true
+          description: |-
+            Survey ID on Alchemer.
+            Deprecated, will be removed on 2022 Jan. 12th, use survey_id instead.
+            Only present when customer satisfaction extension is enabled.
+        satisfaction_answered_at:
+          type: string
+          format: date-time
+          description: |-
+            Date and time when customer answered the survey.
+            Only present when customer satisfaction extension is enabled.
+        satisfaction_sent_at:
+          type: string
+          format: date-time
+          description: |-
+            Date and time when the satisfaction survey was sent to customer.
+            Only present when customer satisfaction extension is enabled.
+        survey_response_id:
+          type: string
+          description: |-
+            ED internal ID for customer response to satisfaction survey.
+            Only present when customer satisfaction extension is enabled.
+        survey_id:
+          type: string
+          description: |
+            ED internal ID for satisfaction survey.
+            Only present when customer satisfaction extension is enabled.
       required:
         - id
     InterventionComment:


### PR DESCRIPTION
Add fields to schema

Nothing to update for postman

Preview from swagger editor:
![Screenshot from 2021-12-06 18-32-50](https://user-images.githubusercontent.com/1823403/144894902-e3278d2c-b2e5-4910-bd52-0db0b116f3a4.png)
