### PR TITLE
Better: ABC List - Add adaptation on title and remove mention of body RD-20087

### DIFF
--- a/docs/interactions/structured-messages/list.md
+++ b/docs/interactions/structured-messages/list.md
@@ -38,7 +38,6 @@ curl -X POST "https://[YOUR DOMAIN].api.digital.ringcentral.com/1.0/contents"
 |-|-|-|
 | **`source_id`** | String | **Optional**. ID of the source. Most interactions are in reply to a message being sent to the agent. In these cases, the source ID is not required. |
 | **`in_reply_to_id`** | String | ID of the message being replied to. |
-| **`body`** | String | The select structured message body. If the device does not support structured messages, this field will be sent as the message. |
 | **`structured_content`** | Object | Payload of the structured message. |
 | **Structured Content Settings** | | |
 | **`structured_content.type`** | String | Type of the structured message. Must be "select". |
@@ -109,7 +108,8 @@ Primary parameters are used by default, however, some parameters are unique or o
 | API Property | Type | Description |
 |-|-|-|
 | **Structured Content Settings** | | |
-| **`structured_content.subtitle`** | String | **Optional**. The subtitle field.<br>Limited to 512 characters.  |
+| **`structured_content.title`** | String | The title field.<br>*Truncated to 512 characters.* |
+| **`structured_content.subtitle`** | String | **Optional**. The subtitle field.<br>Limited to 512 characters. |
 | **`structured_content.attachment_id`** | String | **Optional**. Existing attachment id used to decorate the structured message with an image. Supports private attachments. [Upload attachments](../../../basics/uploads) for you own custom images. |
 | **`structured_content.attachment_fallback_id`** | String | **Optional**. Fallback in case the attachment related to the attachment_id doesn’t meet the source requirements. Must be public. Only jpg, jpeg, png formats. Maximum size of 5 MB. [Upload attachments](../../../basics/uploads) for you own custom images. |
 | **`structured_content.sections`** | Array | **Optional**. An array of sections in which the items will be organized.<br>Limited to 10 elements.<br>If blank, every item will be part of the same section. |


### PR DESCRIPTION
Removes body from the attributes since customer should use `structured-content.title`
![Screenshot from 2022-01-14 10-54-54](https://user-images.githubusercontent.com/1233351/149496220-00cf9a55-34b8-4313-bb45-cb335dd318e2.png)

Specify truncate to 512 chars on title since API allows 1024
![Screenshot from 2022-01-14 10-54-15](https://user-images.githubusercontent.com/1233351/149496223-e8f638f2-67e8-4911-aa59-f24722e5c98f.png)

