### PR TITLE
Add: Topologies to x-tag-groups (left navigation menu on the website) RD-21094

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -61,6 +61,7 @@ x-tag-groups:
       - Folders
       - Presence Status
       - Tasks
+      - Topologies
 tags:
   - name: Events
   - name: Webhooks


### PR DESCRIPTION
As explained in https://github.com/ringcentral/engage-digital-api-docs/pull/71#issuecomment-1057602813 we need to add topologies to the x-tag-group to have it visible in the website navigation menu