### PR TITLE
Better: Enforce UTF-16 code units validation on WA custom fields RD-2…

### DIFF
--- a/docs/interactions/structured-messages/list.md
+++ b/docs/interactions/structured-messages/list.md
@@ -188,7 +188,7 @@ Primary parameters are used by default, however, some parameters are unique or o
 | **Structured Content Settings** | | |
 | **`structured_content.button`** | String | **Optional**. The button text field.<br>Limited to 20 characters.<br>*Truncated to 20 UTF-16 code units.*<br>"See options" by default. |
 | **`structured_content.subtitle`** | String | **Optional**. The subtitle field.<br>*Truncated to 60 UTF-16 code units.* |
-| **`structured_content.header`** | String | **Optional**. The header field.<br>Limited to 60 characters.<br>*Truncated to 60 UTF-16 code units.* |
+| **`structured_content.header`** | String | **Optional**. The header field.<br>Limited to 60 UTF-16 code units. |
 | **Section Settings** | | |
 | **`structured_content.sections.title`** | String | **Optional if there's only a single section**. The title of the section.<br>Limited to 24 characters.<br>*Truncated to 24 UTF-16 code units.* |
 | **Item Settings** | | |

--- a/docs/interactions/structured-messages/template.md
+++ b/docs/interactions/structured-messages/template.md
@@ -136,7 +136,7 @@ Primary parameters are used by default, however, some parameters are unique or o
 | **`structured_content.title`** | String | Limited to 1000 characters.<br>*Truncated to 1000 UTF-16 code units.*<br>Used as the message body. |
 | **Structured Content Settings** | | |
 | **`structured_content.attachment_id`** | String | Supports jpg, jpeg, png, mp4 formats. Supports private attachments. [Upload attachments](../../../basics/uploads) for your own custom images or videos. Should be less than 64 MB. WhatsApp supports videos with only H.264 and AAC codecs and a single audio stream. |
-| **`structured_content.footer`** | String | Limited to 60 characters.<br>*Truncated to 60 UTF-16 code units.* |
+| **`structured_content.footer`** | String | **Optional**. Limited to 60 UTF-16 code units.<br> |
 | **`structured_content.url`** | String | **Ignored** property. |
 | **`structured_content.url_fallback`** | String | **Ignored** property. |
 | **`structured_content.url_text`** | String | **Ignored** property. |

--- a/docs/interactions/structured-messages/template.md
+++ b/docs/interactions/structured-messages/template.md
@@ -136,7 +136,7 @@ Primary parameters are used by default, however, some parameters are unique or o
 | **`structured_content.title`** | String | Limited to 1000 characters.<br>*Truncated to 1000 UTF-16 code units.*<br>Used as the message body. |
 | **Structured Content Settings** | | |
 | **`structured_content.attachment_id`** | String | Supports jpg, jpeg, png, mp4 formats. Supports private attachments. [Upload attachments](../../../basics/uploads) for your own custom images or videos. Should be less than 64 MB. WhatsApp supports videos with only H.264 and AAC codecs and a single audio stream. |
-| **`structured_content.footer`** | String | **Optional**. Limited to 60 UTF-16 code units.<br> |
+| **`structured_content.footer`** | String | **Optional**. Limited to 60 UTF-16 code units. |
 | **`structured_content.url`** | String | **Ignored** property. |
 | **`structured_content.url_fallback`** | String | **Ignored** property. |
 | **`structured_content.url_text`** | String | **Ignored** property. |


### PR DESCRIPTION
…0244

Changes:
- WA List: header doesn't truncate anymore, enforces less or equal than 60 UTF-16 unit count
- WA Template: same for footer, also specifies it's optional
