### PR TITLE
Better: Add synchronization_status and synchronization_error fields to export messages documentation. RD-20491

### DIFF
--- a/docs/digital/exports/main-export-fields.md
+++ b/docs/digital/exports/main-export-fields.md
@@ -98,6 +98,8 @@ Other custom data can be present in the thread export depending on the source ty
 | in_reply_to_author_id    | Source ID                                                     | ObjectId | 523ffffb7aa58d1b6700000f                                        |                                                                                                                      |
 | attachments_count        | Number of attachments                                         | Integer  | 1                                                               |                                                                                                                      |
 | structured_reply_payload | Payload of the structured reply                               | String   | my_payload                                                      | [Sensitive](/digital/exports/#sensitive-columns)                                                                                                            |
+| synchronization_status   | Synchronization status of the message                         | String   | success                                                      | Possible values : <ul><li>success</li> <li>export_pending</li><li>export_failure</li><li>export_aborted</li> <li>like_aborted</li> <li>author_block_aborted</li> <li>delete_aborted</li><li>unpublish_aborted</li></ul> |
+| synchronization_error    | Error message if the synchronization failed or has been aborted | String | hard_bounce - The server was unable to deliver your message (ex: unknown user, mailbox not found). | This field is the concatenation of content.synchronization_error and content.synchronization_error_custom fields |
 
 ## Journal(`Exports::Events`)
 

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -103,8 +103,8 @@ paths:
     put:
       description: >-
         This method activates an existing topology from given attributes and renders it in case of success.
-        
-        
+
+
         Authorization: Only users that have the right to manage topologies.
       operationId: activateTopology
       parameters:
@@ -127,8 +127,8 @@ paths:
     put:
       description: >-
         This method updates an existing topology from given attributes and renders it in case of success.
-        
-        
+
+
         Authorization: only users that have the right to manage topologies. Topology must be inactive or the response will return an error.
       operationId: updateTopology
       parameters:
@@ -155,8 +155,8 @@ paths:
     delete:
       description: >-
         This method destroys an existing topology. It renders topology itself. It renders a 404 if id is invalid.
-        
-        
+
+
         Authorization: Only users that have the right to manage topologies.
       operationId: deleteTopology
       parameters:
@@ -178,8 +178,8 @@ paths:
     get:
       description: >-
         This method renders a topology from given id.
-      
-      
+
+
         Authorization: only users that have the right to manage topologies.
       operationId: getTopology
       parameters:
@@ -202,8 +202,8 @@ paths:
     post:
       description: >-
         This method creates a topology. In case of success it renders the topology, otherwise, it renders an error (422 HTTP code).
-      
-      
+
+
         Authorization: Only users that have the right to manage topologies.
       requestBody:
         required: true
@@ -213,7 +213,7 @@ paths:
               $ref: '#/components/schemas/CreateUpdateTopology'
       responses:
         '200':
-            description: Created topology 
+            description: Created topology
             content:
               application/json:
                 schema:
@@ -224,8 +224,8 @@ paths:
     get:
       description: >-
         This method renders all topologies ordered by name (in alphabetical order).
-        
-        
+
+
         Authorization: Only users that have the right to manage topologies
       responses:
         '200':
@@ -5863,7 +5863,7 @@ paths:
             items:
               type: string
             type: array
-        - description:  >- 
+        - description:  >-
             Whether the user is passwordless or not (boolean).
             Must be used with the corresponding SSO configuration.
           in: query
@@ -7004,6 +7004,8 @@ components:
         status:
           type: string
         synchronization_status:
+          type: string
+        synchronization_error:
           type: string
         thread_id:
           type: string


### PR DESCRIPTION
We should update the documentation because we added synchronization_status and synchronization_error_custom fields in the messages export and API

**Export**:
![doc_export](https://user-images.githubusercontent.com/5880513/159244459-7b880b82-2d78-43fc-b0a3-274092df78a9.png)

**API**:
![doc_api](https://user-images.githubusercontent.com/5880513/159244480-a1a2e886-4f4a-4c1b-9948-c5f05cc38836.png)
