### PR TITLE
Minor: Add a little script to launch preview with docker. RD-23147

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+RUN mkdir /app
+
+WORKDIR /app
+
+ADD . .
+
+RUN pip install -r requirements.txt
+
+CMD mkdocs serve -a 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ If you would like to contribute to the RingCentral documentation effort, fork th
 % mkdocs serve
 ```
 
+Or with docker:
+
+```
+./preview.sh
+```
+
 Then you should be able to load http://localhost:8000 to view the documentation.
 
 ### Generating OpenAPI doc

--- a/preview.sh
+++ b/preview.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build . -t api-doc-preview
+docker run --rm -it -p 8000:8000 api-doc-preview


### PR DESCRIPTION
I always get tricked because my computer still has python2 as default and instructions for this projects require python3

I made a little script that can launch a preview with docker directly by just running `./preview.sh`