### PR TITLE
CI: Fix build with go 1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       if: success()
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests


### PR DESCRIPTION
We are getting the following error on CI runs:

```
Run go install github.com/grokify/spectrum@latest
go: downloading github.com/grokify/spectrum v1.12.6
go: downloading github.com/grokify/mogo v0.40.5
go: downloading github.com/jessevdk/go-flags v1.5.0
go: downloading github.com/getkin/kin-openapi v0.106.0
go: downloading github.com/grokify/gocharts/v2 v2.8.2
go: downloading golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43
go: downloading github.com/invopop/yaml v0.2.0
go: downloading github.com/xuri/excelize/v2 v2.6.1
go: downloading github.com/valyala/quicktemplate v1.7.0
go: downloading github.com/json-iterator/go v1.1.12
go: downloading github.com/go-openapi/swag v0.22.3
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading gonum.org/v1/gonum v0.12.0
go: downloading google.golang.org/protobuf v1.28.1
go: downloading github.com/mattn/go-runewidth v0.0.14
go: downloading github.com/richardlehane/mscfb v1.0.4
go: downloading github.com/xuri/efp v0.0.0-20220603152613-6918739fd470
go: downloading github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22
go: downloading golang.org/x/crypto v0.0.0-20221012134737-56aed061732a
go: downloading golang.org/x/net v0.0.0-20221014081412-f15817d10f9b
go: downloading golang.org/x/text v0.3.8
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/grokify/base36 v1.0.5
go: downloading github.com/rivo/uniseg v0.4.2
go: downloading github.com/richardlehane/msoleps v1.0.3
go: downloading github.com/josharian/intern v1.0.0
# github.com/rivo/uniseg
Error: ../../../../go/pkg/mod/github.com/rivo/uniseg@v0.4.2/properties.go:137:6: missing function body
Error: ../../../../go/pkg/mod/github.com/rivo/uniseg@v0.4.2/properties.go:137:20: syntax error: unexpected [, expecting (
note: module requires Go 1.18
Error: Process completed with exit code 2.
```