### PR TITLE
Fix spectrum version in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Postman generated
       working-directory: specs
       run: |
-        go install github.com/grokify/spectrum@latest
+        go install github.com/grokify/spectrum@v1.15.0
         spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json.new
         diff engage-digital_postman2.json engage-digital_postman2.json.new
   lint:


### PR DESCRIPTION
The [CI fail](https://github.com/ringcentral/engage-digital-api-docs/actions/runs/3742186678/jobs/6353590187) because, in the latest version of [spectrum](https://github.com/grokify/spectrum), the generated postmark file is different that previous version. I fixed the version of spectrum used to the latest version compatible with of [engage-digital_postman2.json](https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/engage-digital_postman2.json).