### PR TITLE
Minor: Add script to generate postman from open api specs. RD-25672

### DIFF
--- a/specs/Dockerfile
+++ b/specs/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.18
+
+RUN go install github.com/grokify/spectrum@v1.15.0 # same as github tests
+
+RUN mkdir /app
+WORKDIR /app
+
+CMD spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,6 +14,12 @@ The following files are used to generate the Postman collection and are not desi
 
 ## Postman Collection
 
+### Script
+
+Run `./gen_postman.sh`
+
+or proceed with the manual installation as described below
+
 Use `spectrum` to create the Postman 2.x collection from the OpenAPI 3 API Specification.
 
 ### Installation

--- a/specs/gen_postman.sh
+++ b/specs/gen_postman.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build . -t api-doc-gen-postman
+docker run --rm -it -v .:/app api-doc-gen-postman


### PR DESCRIPTION
Little script to generate de postman from the open api spec. I used it in https://github.com/ringcentral/engage-digital-api-docs/pull/136/files and it works well