### PR TITLE
Better: Add task autocompletion fields to channels. RD-24456

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -810,6 +810,22 @@ paths:
           required: false
           schema:
             type: integer
+        - description: this field defines the time before a task is auto completed (in seconds).
+          in: query
+          name: task_auto_complete_seconds
+          required: false
+          schema:
+            type: integer
+        - description: >-
+            An array containing id of each category set when auto completing a task
+            (multiple).
+          in: query
+          name: 'auto_complete_category_ids[]'
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         '200':
           content:
@@ -7388,6 +7404,12 @@ components:
         updated_at:
           format: date-time
           type: string
+        auto_complete_category_ids:
+          items:
+            type: string
+          type: array
+        task_auto_complete_seconds:
+          type: integer
     Community:
       properties:
         active:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -6882,6 +6882,18 @@
                       "value": "\u003cinteger\u003e",
                       "description": "Agent SLA warning threshold (must be greater than 0 and less than 100, default value is 0).",
                       "disabled": true
+                    },
+                    {
+                      "key": "task_auto_complete_seconds",
+                      "value": "\u003cinteger\u003e",
+                      "description": "this field defines the time before a task is auto completed (in seconds).",
+                      "disabled": true
+                    },
+                    {
+                      "key": "auto_complete_category_ids[]",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "An array containing id of each category set when auto completing a task (multiple).",
+                      "disabled": true
                     }
                   ]
                 },


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-24456

This PR updates the doc to add the task autocompletion related fields to the channels API.

I updated `specs/engage-digital_openapi3.yaml` and then generated `specs/engage-digital_postman2.json` from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).
