### PR TITLE
Minor: Add ig_followers_count to list of fields in identity export. RD-26034

### DIFF
--- a/docs/digital/exports/main-export-fields.md
+++ b/docs/digital/exports/main-export-fields.md
@@ -244,6 +244,7 @@ List of events containing a `task_id`:
 | tw_following_count               | People the identity follows   | Integer  | 865                                  | Extra (twitter) updated only when there is a new tweet from the user    |
 | tw_statuses_count                | Number of tweets              | Integer  | 1023                                 | Extra (twitter) updated only when there is a new tweet from the user    |
 | tw_location                      | User's location               | String   | Paris                                | Extra (twitter) updated only when there is a new tweet from the user    |
+| ig_followers_count               | People following the identity | Integer  | 395                                  | Extra (Instagram) updated only when there is a new message from the user  |
 | dimelo_type                      | DC Account type               | String   | facebook                             | Extra (DC)                                                              |
 | dimelo_custom_field_1 (up to 10) | DC custom fields              | String   | 01 23 45 67 89                       | Extra (DC)                                                              |
 | fb_bio                           | Facebook bio                  | String   | Painter living in Paris              | Extra (facebook) updated only when there is a new message from the user |


### PR DESCRIPTION
Added `ig_followers_count` field to list of exported fields for Identity model.

![RD-26034](https://user-images.githubusercontent.com/4250060/229523301-002d1833-e5ff-4b07-a8a9-eee9c8faf21b.jpg)
