### PR TITLE
Feature: Add PUT /identity_groups/:id/merge endpoint. RD-26395

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2860,6 +2860,37 @@ paths:
       summary: Updating an identity group
       tags:
         - Identity Groups
+  '/identity_groups/{identityGroupId}/merge':
+    put:
+      description: >-
+        This method merges an identity into an identity group.
+        In case of conflicts, the attributes of the identity group will be kept.
+        The identity group will be returned.
+
+        Authorization​: only users which can update identities.
+      operationId: mergeIdentityGroup
+      parameters:
+        - in: path
+          name: identityGroupId
+          required: true
+          schema:
+            type: string
+        - description: The identity which will be merged into the identity group.
+          in: query
+          name: associated_identity_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityGroup'
+          description: Success
+      summary: Merging an identity into an identity group
+      tags:
+        - Identity Groups
   /interface_locales:
     get:
       description: This method renders all available locales for user interface.

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1398,6 +1398,43 @@
                 ],
                 "description": "This method updates an identity group from given attributes and renders it in case of success.\n\nAuthorization​: no."
               }
+            },
+            {
+              "name": "Merging an identity into an identity group",
+              "request": {
+                "url": {
+                  "raw": "{{ENGAGE_DIGITAL_SERVER_URL}}/1.0/identity_groups/:identityGroupId/merge",
+                  "host": [
+                    "{{ENGAGE_DIGITAL_SERVER_URL}}"
+                  ],
+                  "path": [
+                    "1.0",
+                    "identity_groups",
+                    ":identityGroupId",
+                    "merge"
+                  ],
+                  "query": [
+                    {
+                      "key": "associated_identity_id",
+                      "value": "\u003cstring\u003e",
+                      "description": "The identity which will be merged into the identity group.",
+                      "disabled": true
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "description": "This method merges an identity into an identity group. In case of conflicts, the attributes of the identity group will be kept. The identity group will be returned.\nAuthorization​: only users which can update identities."
+              }
             }
           ]
         },


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-26395

This PR updates the doc to add the `PUT /identity_groups/:id/merge` endpoint.

I updated `specs/engage-digital_openapi3.yaml` and then generated `specs/engage-digital_postman2.json` from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).