### PR TITLE
Minor: Add color_hex to sources API. RD-26458

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -967,7 +967,7 @@ paths:
           required: false
           schema:
             type: string
-        - description: Color of the icon (see S​ ource colors​) (Integer)
+        - description: Color of the icon (see Source colors) (Integer)
           in: query
           name: color
           required: false
@@ -8819,6 +8819,11 @@ components:
             4 Yellow: 5 Orange: 6 Red: 7 Asphalt: 8 Grey: 9
           format: int32
           type: integer
+        color_hex:
+          description: >-
+            Hex code of the color of the icon
+          example: "#A1A1A1"
+          type: string
         community_id:
           type: string
         content_archiving:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -2032,7 +2032,7 @@
                     {
                       "key": "color",
                       "value": "\u003cinteger\u003e",
-                      "description": "Color of the icon (see S​ ource colors​) (Integer)",
+                      "description": "Color of the icon (see Source colors) (Integer)",
                       "disabled": true
                     },
                     {


### PR DESCRIPTION
Add the color_hex to api documentation for sources:

![Screenshot_2023-05-12_11-20-31](https://github.com/ringcentral/engage-digital-api-docs/assets/1866809/b9a2978b-18e5-4114-948d-a48f0f00fdf6)
