### PR TITLE
Feature: Add source_id param to GET /identities. RD-26433

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2487,6 +2487,12 @@ paths:
           required: false
           schema:
             type: string
+        - description: To filter identities on given source's community. Not used if community_id is provided.
+          in: query
+          name: source_id
+          required: false
+          schema:
+            type: string
         - description: To filter on given group id.
           in: query
           name: identity_group_id

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1015,6 +1015,12 @@
                       "disabled": true
                     },
                     {
+                      "key": "source_id",
+                      "value": "\u003cstring\u003e",
+                      "description": "To filter identities on given source's community. Not used if community_id is provided.",
+                      "disabled": true
+                    },
+                    {
                       "key": "identity_group_id",
                       "value": "\u003cstring\u003e",
                       "description": "To filter on given group id.",


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-26433

This PR updates the doc to add the `source_id` param to the `GET /identities` endpoint.

I updated `specs/engage-digital_openapi3.yaml` and then generated `specs/engage-digital_postman2.jso`n from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).