### PR TITLE
Feature: Add common_ancestors_threading to content sources API. RD-26589

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -1324,6 +1324,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: Common ancestors threading. Only on Email sources
+          in: query
+          name: common_ancestors_threading
+          required: false
+          schema:
+            type: boolean
         - description: 'Spam threshold ("disabled", "relaxed", or "strict"). Only on Email sources'
           in: query
           name: spam_assassin_level
@@ -9076,6 +9082,9 @@ components:
           type: string
         threading_heuristics:
           description: Threading_heuristics. Only on Email sources
+          type: boolean
+        common_ancestors_threading:
+          description: Common ancestors threading. Only on Email sources
           type: boolean
         spam_assassin_level:
           description: Spam threshold ("disabled", "relaxed", or "strict"). Only on Email sources

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -2348,6 +2348,12 @@
                       "disabled": true
                     },
                     {
+                      "key": "common_ancestors_threading",
+                      "value": "\u003cboolean\u003e",
+                      "description": "Common ancestors threading. Only on Email sources",
+                      "disabled": true
+                    },
+                    {
                       "key": "spam_assassin_level",
                       "value": "\u003cstring\u003e",
                       "description": "Spam threshold (\"disabled\", \"relaxed\", or \"strict\"). Only on Email sources",


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-26589

This PR updates the doc to add the `common_ancestors_threading` field to the content sources API.

I updated specs/engage-digital_openapi3.yaml and then generated specs/engage-digital_postman2.json from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).