### PR TITLE
Better: Add email headers API. RD-27006

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7636,6 +7636,8 @@ components:
           description: only if content is an email
           additionalProperties:
             type: array
+            items:
+              type: string
           example:
             Subject: ["Hello!"]
             X-Spam-Score: ["9.1"]

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7632,6 +7632,13 @@ components:
           type: array
         foreign_id:
           type: string
+        headers:
+          description: only if content is an email
+          additionalProperties:
+            type: string
+          example:
+            Subject: Hello!
+            X-Spam-Score: "9.1"
         id:
           type: string
         in_reply_to_author_id:
@@ -7709,7 +7716,7 @@ components:
             access_token]
           type: string
     ContentBodyFormatted:
-      description: always contains text a​nd​ html versions.
+      description: always contains text and html versions.
       properties:
         html:
           type: string

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7635,10 +7635,11 @@ components:
         headers:
           description: only if content is an email
           additionalProperties:
-            type: string
+            type: array
           example:
-            Subject: Hello!
-            X-Spam-Score: "9.1"
+            Subject: ["Hello!"]
+            X-Spam-Score: ["9.1"]
+            X-Test: ["1", "2"]
         id:
           type: string
         in_reply_to_author_id:


### PR DESCRIPTION
Add emails headers in API doc

![Screenshot_2023-07-17_11-31-23](https://github.com/ringcentral/engage-digital-api-docs/assets/1866809/0fb84591-d145-464b-8bc0-04a136104969)
![Screenshot_2023-07-17_11-30-59](https://github.com/ringcentral/engage-digital-api-docs/assets/1866809/794b11e6-6f9b-4b06-a3f3-9edf3e6e4715)
