### PR TITLE
Minor: Add the read_only field to the custom field api RD-27142

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2097,7 +2097,7 @@ paths:
             type: integer
         - description: >-
             true or false, that indicates if the custom field is in read-only
-            (default: true).
+            (default: false).
           in: query
           name: read_only
           required: false

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2200,7 +2200,7 @@ paths:
             type: integer
         - description: >-
             true or false, that indicates if the custom field is in read-only
-            (default: true).
+            (default: false).
           in: query
           name: read_only
           required: false

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2095,6 +2095,15 @@ paths:
           schema:
             default: -1
             type: integer
+        - description: >-
+            true or false, that indicates if the custom field is in read-only
+            (default: true).
+          in: query
+          name: read_only
+          required: false
+          schema:
+            default: false
+            type: boolean
       responses:
         '200':
           content:
@@ -2189,6 +2198,15 @@ paths:
           schema:
             format: int32
             type: integer
+        - description: >-
+            true or false, that indicates if the custom field is in read-only
+            (default: true).
+          in: query
+          name: read_only
+          required: false
+          schema:
+            default: false
+            type: boolean
       responses:
         '200':
           content:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -3158,7 +3158,7 @@
                     {
                       "key": "read_only",
                       "value": "\u003cboolean\u003e",
-                      "description": "true or false, that indicates if the custom field is in read-only (default: true).",
+                      "description": "true or false, that indicates if the custom field is in read-only (default: false).",
                       "disabled": true
                     }
                   ]

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -3154,6 +3154,12 @@
                       "value": "\u003cinteger\u003e",
                       "description": "an integer that indicates custom field’s position between others (default: -1).",
                       "disabled": true
+                    },
+                    {
+                      "key": "read_only",
+                      "value": "\u003cboolean\u003e",
+                      "description": "true or false, that indicates if the custom field is in read-only (default: true).",
+                      "disabled": true
                     }
                   ]
                 },
@@ -3256,6 +3262,12 @@
                       "key": "position",
                       "value": "\u003cinteger.int32\u003e",
                       "description": "Custom field’s position.",
+                      "disabled": true
+                    },
+                    {
+                      "key": "read_only",
+                      "value": "\u003cboolean\u003e",
+                      "description": "true or false, that indicates if the custom field is in read-only (default: true).",
                       "disabled": true
                     }
                   ]

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -3267,7 +3267,7 @@
                     {
                       "key": "read_only",
                       "value": "\u003cboolean\u003e",
-                      "description": "true or false, that indicates if the custom field is in read-only (default: true).",
+                      "description": "true or false, that indicates if the custom field is in read-only (default: false).",
                       "disabled": true
                     }
                   ]


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-27142

This PR updates the doc to add the read_only field to the custom fields API.

I updated specs/engage-digital_openapi3.yaml and then generated specs/engage-digital_postman2.json from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).
