### PR TITLE
API: Allow to filter /1.0/identities by identity_group_ids RD-27341

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2541,6 +2541,13 @@ paths:
         - description: To filter on given group id.
           in: query
           name: identity_group_id
+          example: '64fb04186c98bd4ebe19cb24,64fab8d26c98bd7ab989b335'
+          required: false
+          schema:
+            type: string
+        - description: To filter identities on given group ids (separated by commas).
+          in: query
+          name: identity_group_ids
           required: false
           schema:
             type: string

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2541,13 +2541,13 @@ paths:
         - description: To filter on given group id.
           in: query
           name: identity_group_id
-          example: '64fb04186c98bd4ebe19cb24,64fab8d26c98bd7ab989b335'
           required: false
           schema:
             type: string
         - description: To filter identities on given group ids (separated by commas).
           in: query
           name: identity_group_ids
+          example: '64fb04186c98bd4ebe19cb24,64fab8d26c98bd7ab989b335'
           required: false
           schema:
             type: string

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1033,6 +1033,12 @@
                       "disabled": true
                     },
                     {
+                      "key": "identity_group_ids",
+                      "value": "\u003cstring\u003e",
+                      "description": "To filter identities on given group ids (separated by commas).",
+                      "disabled": true
+                    },
+                    {
                       "key": "user_id",
                       "value": "\u003cstring\u003e",
                       "description": "To filter identities on given user id.",


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-27341

This PR updates the doc to add the identity_group_ids filters to the identities API.

I updated specs/engage-digital_openapi3.yaml and then generated specs/engage-digital_postman2.json from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).

![Screenshot 2023-09-11 at 17 12 36](https://github.com/ringcentral/engage-digital-api-docs/assets/1402400/5e07a132-06cb-4736-a545-798e871272a5)
