### PR TITLE
API: Add thread_category_ids params to /bot/handover endpoint RD-27746

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -405,7 +405,7 @@ paths:
     post:
       description: This method is used to handover a conversation between a bot and an agent.
         It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc)
-        and handover between Engage Virtual Agents and human agents
+        and handover between Engage Virtual Agents and human agents. This method recategorize the thread if the thread_category_ids parameter is provided.
       operationId: handoverFromBotToAgent
       parameters:
         - description: Who we are taking the conversation control from (either bot or agent).
@@ -444,6 +444,15 @@ paths:
           required: false
           schema:
             type: string
+        - description: An array containing the new categories to set on the thread.
+          explode: true
+          in: query
+          name: 'thread_category_ids[]'
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         '200':
           content:

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -405,7 +405,7 @@ paths:
     post:
       description: This method is used to handover a conversation between a bot and an agent.
         It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc)
-        and handover between Engage Virtual Agents and human agents. This method recategorize the thread if the thread_category_ids parameter is provided.
+        and handover between Engage Virtual Agents and human agents. This method recategorizes the thread if the thread_category_ids parameter is provided.
       operationId: handoverFromBotToAgent
       parameters:
         - description: Who we are taking the conversation control from (either bot or agent).

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -637,6 +637,12 @@
                       "value": "\u003cstring\u003e",
                       "description": "The id of the intervention that we want to handover (only for Engage Virtual Agent handover).",
                       "disabled": true
+                    },
+                    {
+                      "key": "thread_category_ids[]",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "An array containing the new categories to set on the thread.",
+                      "disabled": true
                     }
                   ]
                 },
@@ -651,7 +657,7 @@
                     "value": "application/json"
                   }
                 ],
-                "description": "This method is used to handover a conversation between a bot and an agent. It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc) and handover between Engage Virtual Agents and human agents"
+                "description": "This method is used to handover a conversation between a bot and an agent. It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc) and handover between Engage Virtual Agents and human agents. This method recategorize the thread if the thread_category_ids parameter is provided."
               }
             }
           ]

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -657,7 +657,7 @@
                     "value": "application/json"
                   }
                 ],
-                "description": "This method is used to handover a conversation between a bot and an agent. It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc) and handover between Engage Virtual Agents and human agents. This method recategorize the thread if the thread_category_ids parameter is provided."
+                "description": "This method is used to handover a conversation between a bot and an agent. It handles 2 different cases, specific sources handover (Messenger for example, see Bots API doc) and handover between Engage Virtual Agents and human agents. This method recategorizes the thread if the thread_category_ids parameter is provided."
               }
             }
           ]


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-27746

his PR updates the doc to add the thread_category_ids params to the /bots/handover endpoint.

I updated specs/engage-digital_openapi3.yaml and then generated specs/engage-digital_postman2.json from it using spectrum (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).

![Screenshot 2023-09-26 at 08 45 27](https://github.com/ringcentral/engage-digital-api-docs/assets/1402400/676164c2-c00d-4949-8383-737e906971dc)
