### PR TITLE
API: Add identity_group_id into interventions and contents api RD-28788

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7699,6 +7699,8 @@ components:
             X-Test: ["1", "2"]
         id:
           type: string
+        identity_group_id:
+          type: string
         in_reply_to_author_id:
           type: string
         in_reply_to_id:
@@ -8467,6 +8469,8 @@ components:
         id:
           type: string
         identity_id:
+          type: string
+        identity_group_id:
           type: string
         last_user_reply_in:
           type: integer


### PR DESCRIPTION
Add identity_group_id to contents:

![Screenshot 2024-01-19 at 16 00 24](https://github.com/ringcentral/engage-digital-api-docs/assets/1402400/225cc213-8052-4653-b1be-99b02ecab693)

Add identity_group_id to interventions:

![Screenshot 2024-01-19 at 16 00 11](https://github.com/ringcentral/engage-digital-api-docs/assets/1402400/6dae2a42-cd1e-490c-86b5-fb4c3d38b36c)


