### PR TITLE
Better: Add the permission filter documentation of the content_sources API. RD-28779

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -908,7 +908,8 @@ paths:
       description: This method renders sources ordered by creation date (ascending).
       operationId: getAllSources
       parameters:
-        - description: Filter by user permissions. Defaults on read for backward compatibility.
+        - description: Filter by user permissions. Default on read for backward compatibility.
+
           in: query
           name: permission
           required: false

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -908,6 +908,13 @@ paths:
       description: This method renders sources ordered by creation date (ascending).
       operationId: getAllSources
       parameters:
+        - description: Filter by user permissions. Defaults on read for backward compatibility.
+          in: query
+          name: permission
+          required: false
+          schema:
+            type: string
+            enum: [read, initiate_discussion]
         - description: The record index to start. Default value is 0.
           in: query
           name: offset

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1974,7 +1974,7 @@
                     {
                       "key": "permission",
                       "value": "\u003cstring\u003e",
-                      "description": "Filter by user permissions. Defaults on read for backward compatibility.",
+                      "description": "Filter by user permissions. Default on read for backward compatibility.",
                       "disabled": true
                     },
                     {

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1972,6 +1972,12 @@
                   ],
                   "query": [
                     {
+                      "key": "permission",
+                      "value": "\u003cstring\u003e",
+                      "description": "Filter by user permissions. Defaults on read for backward compatibility.",
+                      "disabled": true
+                    },
+                    {
                       "key": "offset",
                       "value": "\u003cinteger.int32\u003e",
                       "description": "The record index to start. Default value is 0.",


### PR DESCRIPTION
Added:
![Screenshot_2024-01-23_17-58-16](https://github.com/ringcentral/engage-digital-api-docs/assets/1866809/1831a47a-c763-47b6-893d-c2f222168433)
