### PR TITLE
Better: Case insensitive email filtering on GET users API. RD-29347

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -6470,7 +6470,7 @@ paths:
         returned.
       operationId: getAllUsers
       parameters:
-        - description: To filter users on given email.
+        - description: To filter users on given email (case-insensitive).
           in: query
           name: email
           required: false

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -463,8 +463,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "multipart/form-data:"
                   },
                   {
                     "key": "Accept",
@@ -5923,7 +5923,7 @@
                     {
                       "key": "email",
                       "value": "\u003cstring\u003e",
-                      "description": "To filter users on given email.",
+                      "description": "To filter users on given email (case-insensitive).",
                       "disabled": true
                     },
                     {
@@ -7837,8 +7837,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "application/x-www-form-urlencoded"
                   },
                   {
                     "key": "Accept",
@@ -7925,8 +7925,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "application/x-www-form-urlencoded"
                   },
                   {
                     "key": "Accept",

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -463,8 +463,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Content-Type",
-                    "value": "multipart/form-data:"
+                    "key": "Accept",
+                    "value": "application/json"
                   },
                   {
                     "key": "Accept",
@@ -7837,8 +7837,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Content-Type",
-                    "value": "application/x-www-form-urlencoded"
+                    "key": "Accept",
+                    "value": "application/json"
                   },
                   {
                     "key": "Accept",
@@ -7925,8 +7925,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Content-Type",
-                    "value": "application/x-www-form-urlencoded"
+                    "key": "Accept",
+                    "value": "application/json"
                   },
                   {
                     "key": "Accept",


### PR DESCRIPTION
https://jira.ringcentral.com/browse/RD-29347

This PR updates the doc to specify that the email search is case-insensitive in the users API.

I updated `specs/engage-digital_openapi3.yaml` and then generated `specs/engage-digital_postman2.json` from it using the `./gen_postman.sh` script (cf. https://github.com/ringcentral/engage-digital-api-docs/blob/master/specs/README.md#usage).