### PR TITLE
Better: Add status filter on /interventions RD-29246

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -3166,7 +3166,7 @@ paths:
             type: string
         - description: >-
             To filter interventions on given identity_group_id. This will return
-            interventions associated to any identity in the indentity_group.
+            interventions associated to any identity in the identity_group.
           in: query
           name: identity_group_id
           required: false
@@ -3181,6 +3181,23 @@ paths:
           required: false
           schema:
             type: string
+        - description: >-
+            To filter on the intervention status. Possible values are:
+             - active (open but not deferred)
+             - closed
+             - deferred
+             - opened
+             - reopened
+          in: query
+          name: status
+          required: false
+          schema:
+            enum:
+              - active
+              - closed
+              - deferred
+              - opened
+              - reopened
         - description: >-
             To change the criteria chosen to sort the interventions. The value
             can be “created_at” or “updated_at”.

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -1678,13 +1678,18 @@
                     {
                       "key": "identity_group_id",
                       "value": "\u003cstring\u003e",
-                      "description": "To filter interventions on given identity_group_id. This will return interventions associated to any identity in the indentity_group.",
+                      "description": "To filter interventions on given identity_group_id. This will return interventions associated to any identity in the identity_group.",
                       "disabled": true
                     },
                     {
                       "key": "identity_id",
                       "value": "\u003cstring\u003e",
                       "description": "To filter interventions on given identity_id(s). Can be a single value or an array of string.",
+                      "disabled": true
+                    },
+                    {
+                      "key": "status",
+                      "description": "To filter on the intervention status. Possible values are:\n - active (open but not deferred)\n - closed\n - deferred\n - opened\n - reopened",
                       "disabled": true
                     },
                     {


### PR DESCRIPTION
This MR adds documentation for the new status filter on GET /interventions.
It's my first MR in this project so let me know if I'm doing it wrong.

Swagger:
![Screenshot from 2024-04-15 14-32-27](https://github.com/ringcentral/engage-digital-api-docs/assets/23747016/5abfbff1-d9b4-4b62-8c06-f451c4443a6a)

Postman
![Screenshot from 2024-04-15 14-33-36](https://github.com/ringcentral/engage-digital-api-docs/assets/23747016/8e91c38b-fe48-4b0c-a77b-43b51a5b4cbc)
