### PR TITLE
Better: Allow to filter by sources type RD-29241

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -10,7 +10,7 @@ Use the following files:
 The following files are used to generate the Postman collection and are not designed to be used on their own:
 
 * `engage-digital_postman2.config.json`: configuration file for Spectrum Postman Collection generator.
-* `engage-digital_postman2.base.json`: 
+* `engage-digital_postman2.base.json`:
 
 ## Postman Collection
 
@@ -27,7 +27,7 @@ Use `spectrum` to create the Postman 2.x collection from the OpenAPI 3 API Speci
 The following will install the `spectrum` executable in the `~/go/bin` directory.
 
 ```bash
-$ go get github.com/grokify/spectrum
+$ go install github.com/grokify/spectrum@v1.10.3
 ```
 
 This approach requires `go` 1.16 minimum be installed on your system. See more here: [https://golang.org/](https://golang.org/).

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -938,6 +938,12 @@ paths:
           schema:
             format: int32
             type: integer
+        - description: Filter by type
+          in: query
+          name: type
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           content:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -463,8 +463,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "multipart/form-data:"
                   },
                   {
                     "key": "Accept",
@@ -1998,6 +1998,12 @@
                       "key": "limit",
                       "value": "\u003cinteger.int32\u003e",
                       "description": "The max number of records to return. Default value is 30, max value is 150.",
+                      "disabled": true
+                    },
+                    {
+                      "key": "type",
+                      "value": "\u003cstring\u003e",
+                      "description": "Filter by type",
                       "disabled": true
                     }
                   ]
@@ -7842,8 +7848,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "application/x-www-form-urlencoded"
                   },
                   {
                     "key": "Accept",
@@ -7930,8 +7936,8 @@
                     "value": "Bearer {{ENGAGE_DIGITAL_ACCESS_TOKEN}}"
                   },
                   {
-                    "key": "Accept",
-                    "value": "application/json"
+                    "key": "Content-Type",
+                    "value": "application/x-www-form-urlencoded"
                   },
                   {
                     "key": "Accept",


### PR DESCRIPTION
This adds the documentation for the new type parameter for the content-sources endpoint.