### PR TITLE
Clarify the README to generate the Postman file.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       if: success()
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.18.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests
@@ -22,7 +22,7 @@ jobs:
     - name: Postman generated
       working-directory: specs
       run: |
-        go install github.com/grokify/spectrum@v1.10.3
+        go install github.com/grokify/spectrum@v1.15.0
         spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json.new
         diff engage-digital_postman2.json engage-digital_postman2.json.new
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       if: success()
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.16.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests
@@ -22,7 +22,7 @@ jobs:
     - name: Postman generated
       working-directory: specs
       run: |
-        go install github.com/grokify/spectrum@v1.15.0
+        go install github.com/grokify/spectrum@v1.10.3
         spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json.new
         diff engage-digital_postman2.json engage-digital_postman2.json.new
   lint:

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,7 +10,7 @@ Use the following files:
 The following files are used to generate the Postman collection and are not designed to be used on their own:
 
 * `engage-digital_postman2.config.json`: configuration file for Spectrum Postman Collection generator.
-* `engage-digital_postman2.base.json`: 
+* `engage-digital_postman2.base.json`:
 
 ## Postman Collection
 
@@ -27,10 +27,10 @@ Use `spectrum` to create the Postman 2.x collection from the OpenAPI 3 API Speci
 The following will install the `spectrum` executable in the `~/go/bin` directory.
 
 ```bash
-$ go get github.com/grokify/spectrum
+$ go install github.com/grokify/spectrum@v1.10.3
 ```
 
-This approach requires `go` 1.16 minimum be installed on your system. See more here: [https://golang.org/](https://golang.org/).
+This approach requires `go` 1.16 be installed on your system. See more here: [https://golang.org/](https://golang.org/).
 
 ### Usage
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,20 +14,24 @@ The following files are used to generate the Postman collection and are not desi
 
 ## Postman Collection
 
-### Script
+### Generate Postman Collection file
+
+There are two ways to generate postman collections described below.
+
+#### 1. Script (recommended)
 
 Run `./gen_postman.sh`
 
-or proceed with the manual installation as described below
+#### 2. Manual installation
 
 Use `spectrum` to create the Postman 2.x collection from the OpenAPI 3 API Specification.
 
-### Installation
+##### 2.1 Installation
 
-Be sure to have the version of go specified in the go.mod file. If you have the latest version of go installed, you can install an oldest version with :
+Be sure to have the version of go specified in the Dockerfile. If you have the latest version of go installed, you can install an oldest version with :
 
 ```bash
-$ go install golang.org/dl/go1.16@latest
+$ go install golang.org/dl/go1.18@latest
 ```
 
 See more here: [https://golang.org/](https://golang.org/).
@@ -35,10 +39,10 @@ See more here: [https://golang.org/](https://golang.org/).
 The following will install the `spectrum` executable in the `~/go/bin` directory.
 
 ```bash
-$ ~/go/bin/go1.16 install github.com/grokify/spectrum@v1.10.3
+$ ~/go/bin/go1.16 install github.com/grokify/spectrum@v1.15.0
 ```
 
-### Usage
+##### 2.2 Usage
 
 The following example writes the output to `engage-digital_postman2.json`.
 
@@ -46,13 +50,13 @@ The following example writes the output to `engage-digital_postman2.json`.
 $ ~/go/bin/spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json
 ```
 
+### Testing
+
 In Postman, set the following environment variables:
 
 | Environment Variable | Example |
 |----------------------|---------|
 | `ENGAGE_DIGITAL_SERVER_URL` | `https://{myaccount}.api.engagement.dimelo.com` |
 | `ENGAGE_DIGITAL_ACCESS_TOKEN` | `deadbeef0123456789abcdef` |
-
-#### Testing
 
 Try the "Get all Users" API via "Provisioning" > "Users" > "Getting all Users".

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,13 +24,19 @@ Use `spectrum` to create the Postman 2.x collection from the OpenAPI 3 API Speci
 
 ### Installation
 
+Be sure to have the version of go specified in the go.mod file. If you have the latest version of go installed, you can install an oldest version with :
+
+```bash
+$ go install golang.org/dl/go1.16@latest
+```
+
+See more here: [https://golang.org/](https://golang.org/).
+
 The following will install the `spectrum` executable in the `~/go/bin` directory.
 
 ```bash
-$ go install github.com/grokify/spectrum@v1.10.3
+$ ~/go/bin/go1.16 install github.com/grokify/spectrum@v1.10.3
 ```
-
-This approach requires `go` 1.16 be installed on your system. See more here: [https://golang.org/](https://golang.org/).
 
 ### Usage
 


### PR DESCRIPTION
I had some trouble to install go and have the exact same result that the one produced by the CI with :

```
$ ~/go/bin/spectrum --config engage-digital_postman2.config.json --basePostmanFile engage-digital_postman2.base.json --openapiFile engage-digital_openapi3.yaml --postmanFile engage-digital_postman2.json
```

For example : https://github.com/ringcentral/engage-digital-api-docs/actions/runs/9391479723/job/25863719761

I tried to update go and modules versions, but I had trouble to make tests working.