### PR TITLE
Better: Add first_in_thread to the API RD-30091

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -7714,6 +7714,9 @@ components:
           type: string
         creator_id:
           type: string
+        first_in_thread:
+          description: is true if the content is the first in the thread.
+          type: boolean
         foreign_categories:
           description: is present only if the content has foreign_categories.
           items:


### PR DESCRIPTION
Add the attribute first_in_thread to the doc.