### PR TITLE
Better: Add omnichannelForeignId to ContentSources API for RCX RD-30190

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -9182,6 +9182,9 @@ components:
         name:
           description: Source name
           type: string
+        omnichannel_foreign_id:
+          description: Only on RingCX domains. Identifier of the channel in the external system.
+          type: string
         sla_expired_strategy:
           description: 'SLA expired strategy ("max", "half" or "base")'
           enum:


### PR DESCRIPTION
Adds omnichannel_foreign_id to ContentSources API for RCX domains