### PR TITLE
Improvement: Add the new 409 response documentation reflecting the addition of a cache_lock on PUT /1.0/identity_groups/:id . RD-24154

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2956,6 +2956,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/IdentityGroup'
           description: Success
+        '409':
+          description: >-
+            If the Identity Group is already being updated, it will return a 409
+            error.
       summary: Updating an identity group
       tags:
         - Identity Groups

--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -2957,9 +2957,7 @@ paths:
                 $ref: '#/components/schemas/IdentityGroup'
           description: Success
         '409':
-          description: >-
-            If the Identity Group is already being updated, it will return a 409
-            error.
+          description: If the Identity Group is already being updated, it will return a 409 error.
       summary: Updating an identity group
       tags:
         - Identity Groups


### PR DESCRIPTION
Add the new response to make the clients aware that if they try to spam the PUT route, they can receive a 409 because the ressource will be locked while the 1st operation is being processed.