### PR TITLE
Add thread_category_ids to bot API complete endpoint RD-30684

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -389,6 +389,15 @@ paths:
           required: false
           schema:
             type: boolean
+        - description: An array containing the new categories to add on the thread.
+          explode: true
+          in: query
+          name: 'thread_category_ids[]'
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         '200':
           content:

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -535,6 +535,12 @@
                       "value": "\u003cboolean\u003e",
                       "description": "Wether if the thread should be closed at the same time.",
                       "disabled": true
+                    },
+                    {
+                      "key": "thread_category_ids[]",
+                      "value": "\u003carray.string.csv\u003e",
+                      "description": "An array containing the new categories to add on the thread.",
+                      "disabled": true
                     }
                   ]
                 },


### PR DESCRIPTION
In this MR we add the thread_category_ids parameters to the bot API complete endpoint.

![Screenshot 2024-09-09 at 17 00 06](https://github.com/user-attachments/assets/a0b1eae6-77a5-40b5-9b9f-18271c25c8a3)
