### PR TITLE
Minor: Rename "Default categories" fields in source PUT and schema doc. RD-42485

### DIFF
--- a/specs/engage-digital_openapi3.yaml
+++ b/specs/engage-digital_openapi3.yaml
@@ -1095,7 +1095,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: Default categories
+        - description: Inbound default categories
           in: query
           name: 'default_category_ids[]'
           required: false
@@ -1103,7 +1103,7 @@ paths:
             items:
               type: string
             type: array
-        - description: Default categories (agent messages)
+        - description: Outbound default categories
           in: query
           name: 'user_thread_default_category_ids[]'
           required: false
@@ -9285,7 +9285,7 @@ components:
           format: date-time
           type: string
         default_category_ids:
-          description: Default categories
+          description: Inbound default categories
           items:
             type: string
           type: array
@@ -9441,7 +9441,7 @@ components:
           format: date-time
           type: string
         user_thread_default_category_ids:
-          description: Default categories (agent messages)
+          description: Outbound default categories
           items:
             type: string
           type: array

--- a/specs/engage-digital_openapi3_ngdoc.yaml
+++ b/specs/engage-digital_openapi3_ngdoc.yaml
@@ -764,7 +764,7 @@ paths:
           required: false
           schema:
             type: boolean
-        - description: Default categories
+        - description: Inbound default categories
           in: query
           name: 'default_category_ids[]'
           required: false
@@ -772,7 +772,7 @@ paths:
             items:
               type: string
             type: array
-        - description: Default categories (agent messages)
+        - description: Outbound default categories
           in: query
           name: 'user_thread_default_category_ids[]'
           required: false
@@ -8087,7 +8087,7 @@ components:
           format: date-time
           type: string
         default_category_ids:
-          description: Default categories
+          description: Inbound default categories
           items:
             type: string
           type: array
@@ -8147,7 +8147,7 @@ components:
           format: date-time
           type: string
         user_thread_default_category_ids:
-          description: Default categories (agent messages)
+          description: Outbound default categories
           items:
             type: string
           type: array

--- a/specs/engage-digital_postman2.json
+++ b/specs/engage-digital_postman2.json
@@ -2199,13 +2199,13 @@
                     {
                       "key": "default_category_ids[]",
                       "value": "\u003carray.string.csv\u003e",
-                      "description": "Default categories",
+                      "description": "Inbound default categories",
                       "disabled": true
                     },
                     {
                       "key": "user_thread_default_category_ids[]",
                       "value": "\u003carray.string.csv\u003e",
-                      "description": "Default categories (agent messages)",
+                      "description": "Outbound default categories",
                       "disabled": true
                     },
                     {


### PR DESCRIPTION
Jira ticket: https://jira.ringcentral.com/browse/RD-42485

UI MR: https://git.ringcentral.com/engage-digital/engage-digital/-/merge_requests/14560

User story: https://jira.ringcentral.com/browse/RD-42008

This PR updates the engage digital api docs to rename "Default categories" to "Inbound default categories" and "Default categories (agent messages)" to "Outbound default categories".

I wasn't able to run Docker correctly on my Mac because of ZScaler, so I filled the 3 files including the json manually.

Before:  
<img width="870" height="162" alt="42485-before-ed-api-update-channels-api-doc-to-rename-default-categories-fields-put" src="https://github.com/user-attachments/assets/2cf624d5-7451-4f7b-bf92-481f2d7ee2be" />
<img width="1216" height="1141" alt="42485-before-ed-api-update-channels-api-doc-to-rename-default-categories-fields-source-schema" src="https://github.com/user-attachments/assets/293544d5-b3ca-4386-a351-0b497d4881f2" />

After:
<img width="767" height="159" alt="42485-after-ed-api-update-channels-api-doc-to-rename-default-categories-fields-put" src="https://github.com/user-attachments/assets/b932d957-d066-4c06-a5cb-9522787a6102" />
<img width="1213" height="1143" alt="42485-after-ed-api-update-channels-api-doc-to-rename-default-categories-fields-source-schema" src="https://github.com/user-attachments/assets/17b67b19-3ed2-421f-924c-46417f83646f" />